### PR TITLE
Fixed freezing bug after manually stopping an scenario

### DIFF
--- a/leaderboard/scenarios/scenario_manager.py
+++ b/leaderboard/scenarios/scenario_manager.py
@@ -157,8 +157,7 @@ class ScenarioManager(object):
         """
         Terminate scenario ticking when receiving a signal interrupt
         """
-        with self._my_lock:
-            self._running = False
+        self._running = False
 
     def _reset(self):
         """


### PR DESCRIPTION
Removed a lock causing the simulation to freeze when manually interrupting it. 