### PR TITLE
Glopez/route end fix

### DIFF
--- a/leaderboard/scenarios/route_scenario.py
+++ b/leaderboard/scenarios/route_scenario.py
@@ -425,9 +425,9 @@ class RouteScenario(BasicScenario):
         elif town_name == 'Town06' or town_name == 'Town07':
             amount = 150
         elif town_name == 'Town08':
-            amount = 0 #180
+            amount = 180
         elif town_name == 'Town09':
-            amount = 0 #350
+            amount = 350
         else:
             amount = 1
 


### PR DESCRIPTION
Fixed bug causing the route to end when all scenarios where completed (which passed SUCCESS to the master scenario).

**1.** Added an Idle behavior so that the Behavior part never returns SUCCESS
**2.** Removed the oneshot behavior to allow scenarios to be repeated if the route passes twice through them (which happens a lot at Town08).