### PR TITLE
Readded oneshot behavior

### DIFF
--- a/leaderboard/scenarios/route_scenario.py
+++ b/leaderboard/scenarios/route_scenario.py
@@ -556,9 +556,17 @@ class RouteScenario(BasicScenario):
         subbehavior = py_trees.composites.Parallel(name="Behavior",
                                                    policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL)
 
-        for scenario in self.list_scenarios:
+        for i in range(len(self.list_scenarios)):
+            scenario = self.list_scenarios[i]
             if scenario.scenario.behavior is not None and scenario.scenario.behavior.name != "MasterScenario":
-                subbehavior.add_child(scenario.scenario.behavior)
+                name = "{} - {}".format(i, scenario.scenario.behavior.name)
+                oneshot_idiom = oneshot_behavior(
+                    name=name,
+                    variable_name=name,
+                    behaviour=scenario.scenario.behavior)
+
+
+                subbehavior.add_child(oneshot_idiom)
 
         subbehavior.add_child(Idle()) # The behaviours cannot make the scenario stop
         behavior.add_child(subbehavior)


### PR DESCRIPTION
Readded oneshot behavior as scenarios that destroy actors cannot be repeated (had tested S7 to S 10, which only modify the traffic lights)