### PR TITLE
Glopezdiest/failure message

### DIFF
--- a/leaderboard/scenarios/scenario_manager.py
+++ b/leaderboard/scenarios/scenario_manager.py
@@ -281,8 +281,8 @@ class ScenarioManager(object):
             print("> ")
             print("> Score: ")
             print("> - Route Completed [{}]:      {}%".format(route_symbol, route_completed))
-            print("> - Collisions [{}]:           {} times".format(collision_symbol, collisions))
             print("> - Outside route lanes [{}]:  {}%".format(outside_symbol, outside_route_lanes))
+            print("> - Collisions [{}]:           {} times".format(collision_symbol, collisions))
             print("> - Red lights run [{}]:       {} times".format(red_light_symbol, red_light))
             print("> - Stop signs run [{}]:       {} times\n".format(stop_symbol, stop_signs))
 


### PR DESCRIPTION
Added more info to the message sent after the route is finished. Now it looks like this:

![Newmessage](https://user-images.githubusercontent.com/58212725/76775389-9416ac00-67a5-11ea-8e67-173759b64333.png)


The first message has three variants:
- SUCCESS: Congratulations, route finished!
- FAILED: The actor timed out
- FAILED: The actor deviated from the route

The rest of the values are taken from the atomic criterias via blackboard variables and the tick / cross quickly show if the agent failed there or not

**Possible drawback:**

- Tick and colors might create problems depending on the type of system
- Order of items is important