### PR TITLE
Fixed bug causing ZeroDivisisonError

### DIFF
--- a/leaderboard/utils/statistics_manager.py
+++ b/leaderboard/utils/statistics_manager.py
@@ -202,7 +202,7 @@ class StatisticsManager(object):
                 global_record.scores['score_composed'] += route_record.scores['score_composed']
 
                 for key in global_record.infractions.keys():
-                    route_length_kms = route_record.scores['score_route'] * route_record.meta['route_length'] / 1000.0
+                    route_length_kms = max(route_record.scores['score_route'] * route_record.meta['route_length'] / 1000.0, 0.001)
                     if isinstance(global_record.infractions[key], list):
                         global_record.infractions[key] = len(route_record.infractions[key]) / route_length_kms
                     else:


### PR DESCRIPTION
_route_length_kms_ (distance traveled by the agent) now has a minimum of 0.001 to avoid ZeroDivisionError.