### PR TITLE
 fixing the track selection

### DIFF
--- a/leaderboard/autoagents/agent_wrapper.py
+++ b/leaderboard/autoagents/agent_wrapper.py
@@ -154,7 +154,7 @@ class AgentWrapper(object):
             sensor.listen(CallBack(sensor_spec['id'], sensor, self._agent.sensor_interface))
             self._sensors_list.append(sensor)
 
-        self._validate_sensor_configuration(self._agent.track)
+        self._validate_sensor_configuration(track)
 
         while not self._agent.all_sensors_ready():
             if debug_mode:
@@ -166,7 +166,6 @@ class AgentWrapper(object):
         Ensure that the sensor configuration is valid, in case the challenge mode is used
         Returns true on valid configuration, false otherwise
         """
-
         if Track(selected_track) != self._agent.track:
             raise SensorConfigurationInvalid("You are submitting to the wrong track [{}]!".format(Track(selected_track)))
 

--- a/leaderboard/autoagents/autonomous_agent.py
+++ b/leaderboard/autoagents/autonomous_agent.py
@@ -23,8 +23,8 @@ class Track(Enum):
     """
     This enum represents the different tracks of the CARLA AD leaderboard.
     """
-    SENSORS = 1
-    MAP = 2
+    SENSORS = 'SENSORS'
+    MAP = 'MAP'
 
 class AutonomousAgent(object):
 

--- a/leaderboard/autoagents/dummy_agent.py
+++ b/leaderboard/autoagents/dummy_agent.py
@@ -26,7 +26,7 @@ class DummyAgent(AutonomousAgent):
         """
         Setup the agent parameters
         """
-        self.track = Track.SENSORS
+        self.track = Track.MAP
 
     def sensors(self):
         """


### PR DESCRIPTION
When I run the example.

`python3 leaderboard/leaderboard_evaluator.py  -a leaderboard/autoagents/dummy_agent.py --scenarios data/all_towns_traffic_scenarios_public.json  --routes data/routes_training.xml --track MAP`

I get the following error.
`Illegal sensor used for Track [Track.SENSORS]!
`

I saw some problems.

* The enum was expect ints not strings
* The agent track was being compared with itself not with the scenario track
* The dummy agent had a wrong track associated.

Here is the PR solving those issues.