### PR TITLE
Increased timeouts

### DIFF
--- a/leaderboard/leaderboard_evaluator.py
+++ b/leaderboard/leaderboard_evaluator.py
@@ -85,7 +85,7 @@ class LeaderboardEvaluator(object):
         self.module_agent = importlib.import_module(module_name)
 
         # Create the ScenarioManager
-        self.manager = ScenarioManager(args.debug > 1, args.challenge_mode)
+        self.manager = ScenarioManager(args.debug > 1, args.challenge_mode, self.client_timeout)
 
         # Time control for summary purposes
         self._start_time = GameTime.get_time()
@@ -288,9 +288,11 @@ class LeaderboardEvaluator(object):
             crash_message = "Simulation crashed"
             entry_status = "Crashed"
 
+            self._register_statistics(config, args.checkpoint, entry_status, crash_message)
+
             if args.record:
                 self.client.stop_recorder()
-            self._register_statistics(config, args.checkpoint, entry_status, crash_message)
+
             self._cleanup()
             sys.exit(-1)
 
@@ -319,8 +321,10 @@ class LeaderboardEvaluator(object):
         # Stop the scenario
         try:
             self.manager.stop_scenario()
-            self.client.stop_recorder()
             self._register_statistics(config, args.checkpoint, entry_status, crash_message)
+
+            if args.record:
+                self.client.stop_recorder()
 
             # Remove all actors
             scenario.remove_all_actors()
@@ -376,7 +380,7 @@ def main():
     parser.add_argument('--spectator', type=bool, help='Switch spectator view on?', default=True)
     parser.add_argument('--record', type=str, default='',
                         help='Use CARLA recording feature to create a recording of the scenario')
-    parser.add_argument('--timeout', default="30.0",
+    parser.add_argument('--timeout', default="60.0",
                         help='Set the CARLA client timeout value in seconds')
 
     # simulation setup

--- a/leaderboard/scenarios/route_scenario.py
+++ b/leaderboard/scenarios/route_scenario.py
@@ -48,10 +48,8 @@ from leaderboard.utils.route_manipulation import interpolate_trajectory
 
 ROUTESCENARIO = ["RouteScenario"]
 
-MAX_ALLOWED_RADIUS_SENSOR = 5.0
-SECONDS_GIVEN_PER_METERS = 0.4
+SECONDS_GIVEN_PER_METERS = 0.8
 INITIAL_SECONDS_DELAY = 5.0
-MAX_CONNECTION_ATTEMPTS = 5
 
 NUMBER_CLASS_TRANSLATION = {
     "Scenario1": ControlLoss,
@@ -548,7 +546,7 @@ class RouteScenario(BasicScenario):
 
         blocked_criterion = ActorSpeedAboveThresholdTest(self.ego_vehicles[0],
                                                          speed_threshold=0.1,
-                                                         below_threshold_max_time=90.0,
+                                                         below_threshold_max_time=180.0,
                                                          terminate_on_failure=True,
                                                          name="AgentBlockedTest")
 

--- a/leaderboard/scenarios/scenario_manager.py
+++ b/leaderboard/scenarios/scenario_manager.py
@@ -43,7 +43,7 @@ class ScenarioManager(object):
     4. If needed, cleanup with manager.stop_scenario()
     """
 
-    def __init__(self, debug_mode=False, challenge_mode=False):
+    def __init__(self, debug_mode=False, challenge_mode=False, timeout=10):
         """
         Setups up the parameters, which will be filled at load_scenario()
         """
@@ -58,9 +58,11 @@ class ScenarioManager(object):
         self._agent = None
         self._running = False
         self._timestamp_last_run = 0.0
+        self._timeout = float(timeout)
 
         # Used to detect the simulation is down, but doesn't create any exception
-        self._watchdog = Watchdog(5)
+        watchdog_timeout = max(5, self._timeout - 2)
+        self._watchdog = Watchdog(watchdog_timeout)
 
         self.scenario_duration_system = 0.0
         self.scenario_duration_game = 0.0
@@ -168,7 +170,7 @@ class ScenarioManager(object):
             self.ego_vehicles[0].apply_control(ego_action)
 
         if self._running and self.get_running_status():
-            CarlaDataProvider.get_world().tick()
+            CarlaDataProvider.get_world().tick(self._timeout)
 
     def get_running_status(self):
         """

--- a/leaderboard/utils/route_parser.py
+++ b/leaderboard/utils/route_parser.py
@@ -88,7 +88,7 @@ class RouteParser(object):
         route_weather = route.find("weather")
         if route_weather is None:
 
-            weather = carla.WeatherParameters(sun_altitude_angle = 70)
+            weather = carla.WeatherParameters(sun_altitude_angle=70, cloudiness=70)
 
         else:
             weather = carla.WeatherParameters()


### PR DESCRIPTION
Timeout changes:
- Increased **client timeout** from 30s to **60s**
- Increased **agent blocked** criteria timeout from 90s to **180s**
- Increased the amount of **time given per meter** from 0.4s/m to **0.8s/m**
- Increased the ***world.tick()* timeout** from a fixed 10s to match the client timeout (**60s**)
- Increased the **watchdog timeout** from 5s (last PR), to be a little lower than the client timeout (**58s**). It has to be lower and not equal to ensure it gets triggered before the simulation ends, stopping the scenario

Other changes:
- Moved the recorder after the registering of the statistics, to ensure they are printed (the recorder might get stuck if the simulation crashes)
- Added some clouds to avoid the simulation being too bright
- Removed some unused varaibles at *route_scenario.py*:
    - MAX_ALLOWED_RADIUS_SENSOR is already at *agent_wrapper.py*
    - MAX_CONNECTION_ATTEMPTS is already at *sensor_interface.py*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/55)
<!-- Reviewable:end -->
