### PR TITLE
Fixed logic to resume from empty checkpoints.

### DIFF
--- a/leaderboard/utils/route_indexer.py
+++ b/leaderboard/utils/route_indexer.py
@@ -49,7 +49,11 @@ class RouteIndexer():
         if data:
             checkpoint_dict = dictor(data, '_checkpoint')
             if checkpoint_dict and 'progress' in checkpoint_dict:
-                current_route, total_routes = checkpoint_dict['progress']
+                progress = checkpoint_dict['progress']
+                if not progress:
+                    current_route = 0
+                else:
+                    current_route, total_routes = progress
                 if current_route <= self.total:
                     self._index = current_route
                 else:


### PR DESCRIPTION
The leaderboard crashes if the previous leaderboard run did not complete a route because the progress entry in the json file is an empty list. This PR ensures that the code doesn't directly try to unpack the list, and manually sets the current_route to 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/57)
<!-- Reviewable:end -->
