### PR TITLE
Added runtime watchdogs

### DIFF
--- a/leaderboard/leaderboard_evaluator.py
+++ b/leaderboard/leaderboard_evaluator.py
@@ -106,7 +106,7 @@ class LeaderboardEvaluator(object):
         Terminate scenario ticking when receiving a signal interrupt
         """
         if self._agent_watchdog and not self._agent_watchdog.get_status():
-            raise RuntimeError("Timeout: Agent took too long to setup")
+            raise RuntimeError("Timeout: Agent took longer than {}s to setup".format(self.client_timeout))
         elif self.manager:
             self.manager.signal_handler(signum, frame)
 


### PR DESCRIPTION
Fixed bug causing the watchdog to not properly stop the simulation even if there was a timeout during runtime. This was caused by the `_signal_handler()` at *scenario_manager.py* not raising an exception when the watchdog triggered, causing the *leaderboard_evaluator.py* to never stop the simulation.

With the watchdog improvement of [this PR at SR](https://github.com/carla-simulator/scenario_runner/pull/754), two separate watchdogs can be made, one that tracks the simulation, and another one that tracks the agent. A timeout caused by the simulation, as any other error, will stop the LB, correctly saving the statistics. The timeout given by the agent watchdog is treated as any other error coming from the agent, stopping the route and moving to the next one. 

**IMPORTANT:** Note that the PR adds a new dependency to SR (*simple-watchdog-timer*).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/86)
<!-- Reviewable:end -->
