### PR TITLE
Added allow all sensors parameter

### DIFF
--- a/leaderboard/autoagents/agent_wrapper.py
+++ b/leaderboard/autoagents/agent_wrapper.py
@@ -74,7 +74,7 @@ class AgentWrapper(object):
         """
         return self._agent()
 
-    def setup_sensors(self, vehicle, debug_mode=False):
+    def setup_sensors(self, vehicle, allow_all_sensors=False):
         """
         Create the sensors defined by the user and attach them to the ego-vehicle
         :param vehicle: ego vehicle
@@ -90,44 +90,14 @@ class AgentWrapper(object):
                 delta_time = CarlaDataProvider.get_world().get_settings().fixed_delta_seconds
                 frame_rate = 1 / delta_time
                 sensor = SpeedometerReader(vehicle, frame_rate)
-            # These are the sensors spawned on the carla world
             else:
+                # These are the sensors spawned on the carla world
                 bp = bp_library.find(str(sensor_spec['type']))
-                if sensor_spec['type'].startswith('sensor.camera'):
-                    bp.set_attribute('image_size_x', str(sensor_spec['width']))
-                    bp.set_attribute('image_size_y', str(sensor_spec['height']))
-                    bp.set_attribute('fov', str(sensor_spec['fov']))
-                    bp.set_attribute('lens_circle_multiplier', str(3.0))
-                    bp.set_attribute('lens_circle_falloff', str(3.0))
-                    bp.set_attribute('chromatic_aberration_intensity', str(0.5))
-                    bp.set_attribute('chromatic_aberration_offset', str(0))
 
-                    sensor_location = carla.Location(x=sensor_spec['x'], y=sensor_spec['y'],
-                                                     z=sensor_spec['z'])
-                    sensor_rotation = carla.Rotation(pitch=sensor_spec['pitch'],
-                                                     roll=sensor_spec['roll'],
-                                                     yaw=sensor_spec['yaw'])
-                elif sensor_spec['type'].startswith('sensor.lidar'):
-                    bp.set_attribute('range', str(85))
-                    bp.set_attribute('rotation_frequency', str(10))
-                    bp.set_attribute('channels', str(64))
-                    bp.set_attribute('upper_fov', str(10))
-                    bp.set_attribute('lower_fov', str(-30))
-                    bp.set_attribute('points_per_second', str(600000))
-                    bp.set_attribute('atmosphere_attenuation_rate', str(0.004))
-                    bp.set_attribute('dropoff_general_rate', str(0.45))
-                    bp.set_attribute('dropoff_intensity_limit', str(0.8))
-                    bp.set_attribute('dropoff_zero_intensity', str(0.4))
-                    sensor_location = carla.Location(x=sensor_spec['x'], y=sensor_spec['y'],
-                                                     z=sensor_spec['z'])
-                    sensor_rotation = carla.Rotation(pitch=sensor_spec['pitch'],
-                                                     roll=sensor_spec['roll'],
-                                                     yaw=sensor_spec['yaw'])
-                elif sensor_spec['type'].startswith('sensor.other.radar'):
-                    bp.set_attribute('horizontal_fov', str(sensor_spec['fov']))  # degrees
-                    bp.set_attribute('vertical_fov', str(sensor_spec['fov']))  # degrees
-                    bp.set_attribute('points_per_second', '1500')
-                    bp.set_attribute('range', '100')  # meters
+                if allow_all_sensors:
+                    for key, value in sensor_spec.items():
+                        if key not in ("id", "type", "x", "y", "z", "pitch", "roll", "yaw"):
+                            bp.set_attribute(str(key), str(value))
 
                     sensor_location = carla.Location(x=sensor_spec['x'],
                                                      y=sensor_spec['y'],
@@ -135,34 +105,78 @@ class AgentWrapper(object):
                     sensor_rotation = carla.Rotation(pitch=sensor_spec['pitch'],
                                                      roll=sensor_spec['roll'],
                                                      yaw=sensor_spec['yaw'])
+                else:
+                    if sensor_spec['type'].startswith('sensor.camera'):
+                        bp.set_attribute('image_size_x', str(sensor_spec['width']))
+                        bp.set_attribute('image_size_y', str(sensor_spec['height']))
+                        bp.set_attribute('fov', str(sensor_spec['fov']))
+                        bp.set_attribute('lens_circle_multiplier', str(3.0))
+                        bp.set_attribute('lens_circle_falloff', str(3.0))
+                        bp.set_attribute('chromatic_aberration_intensity', str(0.5))
+                        bp.set_attribute('chromatic_aberration_offset', str(0))
 
-                elif sensor_spec['type'].startswith('sensor.other.gnss'):
-                    bp.set_attribute('noise_alt_stddev', str(0.000005))
-                    bp.set_attribute('noise_lat_stddev', str(0.000005))
-                    bp.set_attribute('noise_lon_stddev', str(0.000005))
-                    bp.set_attribute('noise_alt_bias', str(0.0))
-                    bp.set_attribute('noise_lat_bias', str(0.0))
-                    bp.set_attribute('noise_lon_bias', str(0.0))
+                        sensor_location = carla.Location(x=sensor_spec['x'], y=sensor_spec['y'],
+                                                        z=sensor_spec['z'])
+                        sensor_rotation = carla.Rotation(pitch=sensor_spec['pitch'],
+                                                         roll=sensor_spec['roll'],
+                                                        yaw=sensor_spec['yaw'])
+                    elif sensor_spec['type'].startswith('sensor.lidar'):
+                        bp.set_attribute('range', str(85))
+                        bp.set_attribute('rotation_frequency', str(10))
+                        bp.set_attribute('channels', str(64))
+                        bp.set_attribute('upper_fov', str(10))
+                        bp.set_attribute('lower_fov', str(-30))
+                        bp.set_attribute('points_per_second', str(600000))
+                        bp.set_attribute('atmosphere_attenuation_rate', str(0.004))
+                        bp.set_attribute('dropoff_general_rate', str(0.45))
+                        bp.set_attribute('dropoff_intensity_limit', str(0.8))
+                        bp.set_attribute('dropoff_zero_intensity', str(0.4))
+                        sensor_location = carla.Location(x=sensor_spec['x'], y=sensor_spec['y'],
+                                                        z=sensor_spec['z'])
+                        sensor_rotation = carla.Rotation(pitch=sensor_spec['pitch'],
+                                                        roll=sensor_spec['roll'],
+                                                        yaw=sensor_spec['yaw'])
+                    elif sensor_spec['type'].startswith('sensor.other.radar'):
+                        bp.set_attribute('horizontal_fov', str(sensor_spec['fov']))  # degrees
+                        bp.set_attribute('vertical_fov', str(sensor_spec['fov']))  # degrees
+                        bp.set_attribute('points_per_second', '1500')
+                        bp.set_attribute('range', '100')  # meters
 
-                    sensor_location = carla.Location(x=sensor_spec['x'],
-                                                     y=sensor_spec['y'],
-                                                     z=sensor_spec['z'])
-                    sensor_rotation = carla.Rotation()
+                        sensor_location = carla.Location(x=sensor_spec['x'],
+                                                        y=sensor_spec['y'],
+                                                        z=sensor_spec['z'])
+                        sensor_rotation = carla.Rotation(pitch=sensor_spec['pitch'],
+                                                        roll=sensor_spec['roll'],
+                                                        yaw=sensor_spec['yaw'])
 
-                elif sensor_spec['type'].startswith('sensor.other.imu'):
-                    bp.set_attribute('noise_accel_stddev_x', str(0.001))
-                    bp.set_attribute('noise_accel_stddev_y', str(0.001))
-                    bp.set_attribute('noise_accel_stddev_z', str(0.015))
-                    bp.set_attribute('noise_gyro_stddev_x', str(0.001))
-                    bp.set_attribute('noise_gyro_stddev_y', str(0.001))
-                    bp.set_attribute('noise_gyro_stddev_z', str(0.001))
+                    elif sensor_spec['type'].startswith('sensor.other.gnss'):
+                        bp.set_attribute('noise_alt_stddev', str(0.000005))
+                        bp.set_attribute('noise_lat_stddev', str(0.000005))
+                        bp.set_attribute('noise_lon_stddev', str(0.000005))
+                        bp.set_attribute('noise_alt_bias', str(0.0))
+                        bp.set_attribute('noise_lat_bias', str(0.0))
+                        bp.set_attribute('noise_lon_bias', str(0.0))
 
-                    sensor_location = carla.Location(x=sensor_spec['x'],
-                                                     y=sensor_spec['y'],
-                                                     z=sensor_spec['z'])
-                    sensor_rotation = carla.Rotation(pitch=sensor_spec['pitch'],
-                                                     roll=sensor_spec['roll'],
-                                                     yaw=sensor_spec['yaw'])
+                        sensor_location = carla.Location(x=sensor_spec['x'],
+                                                        y=sensor_spec['y'],
+                                                        z=sensor_spec['z'])
+                        sensor_rotation = carla.Rotation()
+
+                    elif sensor_spec['type'].startswith('sensor.other.imu'):
+                        bp.set_attribute('noise_accel_stddev_x', str(0.001))
+                        bp.set_attribute('noise_accel_stddev_y', str(0.001))
+                        bp.set_attribute('noise_accel_stddev_z', str(0.015))
+                        bp.set_attribute('noise_gyro_stddev_x', str(0.001))
+                        bp.set_attribute('noise_gyro_stddev_y', str(0.001))
+                        bp.set_attribute('noise_gyro_stddev_z', str(0.001))
+
+                        sensor_location = carla.Location(x=sensor_spec['x'],
+                                                        y=sensor_spec['y'],
+                                                        z=sensor_spec['z'])
+                        sensor_rotation = carla.Rotation(pitch=sensor_spec['pitch'],
+                                                        roll=sensor_spec['roll'],
+                                                        yaw=sensor_spec['yaw'])
+
                 # create sensor
                 sensor_transform = carla.Transform(sensor_location, sensor_rotation)
                 sensor = CarlaDataProvider.get_world().spawn_actor(bp, sensor_transform, vehicle)
@@ -173,57 +187,57 @@ class AgentWrapper(object):
         # Tick once to spawn the sensors
         CarlaDataProvider.get_world().tick()
 
+    @staticmethod
+    def validate_agent_track(agent_track, selected_track):
+        if Track(selected_track) != agent_track:
+            raise ValueError("You are submitting to the wrong track [{}]!".format(Track(selected_track)))
 
     @staticmethod
-    def validate_sensor_configuration(sensors, agent_track, selected_track):
+    def validate_sensor_configuration(sensors, agent_track, allow_all_sensors=False):
         """
         Ensure that the sensor configuration is valid, in case the challenge mode is used
         Returns true on valid configuration, false otherwise
         """
-        if Track(selected_track) != agent_track:
-            raise SensorConfigurationInvalid("You are submitting to the wrong track [{}]!".format(Track(selected_track)))
-
         sensor_count = {}
         sensor_ids = []
 
         for sensor in sensors:
 
-            # Check if the is has been already used
+            # Check if the id has been already used
             sensor_id = sensor['id']
             if sensor_id in sensor_ids:
                 raise SensorConfigurationInvalid("Duplicated sensor tag [{}]".format(sensor_id))
             else:
                 sensor_ids.append(sensor_id)
 
-            # Check if the sensor is valid
-            if agent_track == Track.SENSORS:
-                if sensor['type'].startswith('sensor.opendrive_map'):
-                    raise SensorConfigurationInvalid("Illegal sensor used for Track [{}]!".format(agent_track))
+            if not allow_all_sensors:
+                # Check if the sensor is valid
+                if agent_track == Track.SENSORS:
+                    if sensor['type'].startswith('sensor.opendrive_map'):
+                        raise SensorConfigurationInvalid("Illegal sensor used for Track [{}]!".format(agent_track))
 
-            # Check the sensors validity
-            if sensor['type'] not in AgentWrapper.allowed_sensors:
-                raise SensorConfigurationInvalid("Illegal sensor used. {} are not allowed!".format(sensor['type']))
+                # Check the sensors validity
+                if sensor['type'] not in AgentWrapper.allowed_sensors:
+                    raise SensorConfigurationInvalid("Illegal sensor used. {} are not allowed!".format(sensor['type']))
 
-            # Check the extrinsics of the sensor
-            if 'x' in sensor and 'y' in sensor and 'z' in sensor:
-                if math.sqrt(sensor['x']**2 + sensor['y']**2 + sensor['z']**2) > MAX_ALLOWED_RADIUS_SENSOR:
+                # Check the extrinsics of the sensor
+                if 'x' in sensor and 'y' in sensor and 'z' in sensor:
+                    if math.sqrt(sensor['x']**2 + sensor['y']**2 + sensor['z']**2) > MAX_ALLOWED_RADIUS_SENSOR:
+                        raise SensorConfigurationInvalid(
+                            "Illegal sensor extrinsics used. Sensor is further than {}m from the ego's origin".format(MAX_ALLOWED_RADIUS_SENSOR))
+
+                # Check the amount of sensors
+                if sensor['type'] in sensor_count:
+                    sensor_count[sensor['type']] += 1
+                else:
+                    sensor_count[sensor['type']] = 1
+
+                if sensor_count[sensor['type']] > SENSORS_LIMITS[sensor['type']]:
                     raise SensorConfigurationInvalid(
-                        "Illegal sensor extrinsics used for Track [{}]!".format(agent_track))
-
-            # Check the amount of sensors
-            if sensor['type'] in sensor_count:
-                sensor_count[sensor['type']] += 1
-            else:
-                sensor_count[sensor['type']] = 1
-
-
-        for sensor_type, max_instances_allowed in SENSORS_LIMITS.items():
-            if sensor_type in sensor_count and sensor_count[sensor_type] > max_instances_allowed:
-                raise SensorConfigurationInvalid(
-                    "Too many {} used! "
-                    "Maximum number allowed is {}, but {} were requested.".format(sensor_type,
-                                                                                  max_instances_allowed,
-                                                                                  sensor_count[sensor_type]))
+                        "Too many {} used! "
+                        "Maximum number allowed is {}, but {} were requested.".format(sensor['type'],
+                                                                                      SENSORS_LIMITS[sensor['type']],
+                                                                                      sensor_count[sensor['type']]))
 
     def cleanup(self):
         """

--- a/leaderboard/autoagents/agent_wrapper.py
+++ b/leaderboard/autoagents/agent_wrapper.py
@@ -99,12 +99,12 @@ class AgentWrapper(object):
                         if key not in ("id", "type", "x", "y", "z", "pitch", "roll", "yaw"):
                             bp.set_attribute(str(key), str(value))
 
-                    sensor_location = carla.Location(x=sensor_spec['x'],
-                                                     y=sensor_spec['y'],
-                                                     z=sensor_spec['z'])
-                    sensor_rotation = carla.Rotation(pitch=sensor_spec['pitch'],
-                                                     roll=sensor_spec['roll'],
-                                                     yaw=sensor_spec['yaw'])
+                    sensor_location = carla.Location(x=sensor_spec.get('x', 0.0),
+                                                     y=sensor_spec.get('y', 0.0),
+                                                     z=sensor_spec.get('z', 0.0))
+                    sensor_rotation = carla.Rotation(pitch=sensor_spec.get('pitch', 0.0),
+                                                     roll=sensor_spec.get('roll', 0.0),
+                                                     yaw=sensor_spec.get('yaw', 0.0))
                 else:
                     if sensor_spec['type'].startswith('sensor.camera'):
                         bp.set_attribute('image_size_x', str(sensor_spec['width']))
@@ -235,9 +235,7 @@ class AgentWrapper(object):
                 if sensor_count[sensor['type']] > SENSORS_LIMITS[sensor['type']]:
                     raise SensorConfigurationInvalid(
                         "Too many {} used! "
-                        "Maximum number allowed is {}, but {} were requested.".format(sensor['type'],
-                                                                                      SENSORS_LIMITS[sensor['type']],
-                                                                                      sensor_count[sensor['type']]))
+                        "Maximum number allowed is {}.".format(sensor['type'], SENSORS_LIMITS[sensor['type']]))
 
     def cleanup(self):
         """

--- a/leaderboard/scenarios/scenario_manager.py
+++ b/leaderboard/scenarios/scenario_manager.py
@@ -45,7 +45,7 @@ class ScenarioManager(object):
     """
 
 
-    def __init__(self, timeout, debug_mode=False):
+    def __init__(self, timeout, debug_mode=False, allow_all_sensors=False):
         """
         Setups up the parameters, which will be filled at load_scenario()
         """
@@ -56,6 +56,7 @@ class ScenarioManager(object):
         self.other_actors = None
 
         self._debug_mode = debug_mode
+        self._allow_all_sensors = allow_all_sensors
         self._agent = None
         self._running = False
         self._timestamp_last_run = 0.0
@@ -116,7 +117,7 @@ class ScenarioManager(object):
         # To print the scenario tree uncomment the next line
         # py_trees.display.render_dot_tree(self.scenario_tree)
 
-        self._agent.setup_sensors(self.ego_vehicles[0], self._debug_mode)
+        self._agent.setup_sensors(self.ego_vehicles[0], self._allow_all_sensors)
 
     def run_scenario(self):
         """

--- a/leaderboard/utils/statistics_manager.py
+++ b/leaderboard/utils/statistics_manager.py
@@ -268,7 +268,7 @@ class StatisticsManager(object):
         save_dict(endpoint, data)
 
     @staticmethod
-    def save_global_record(route_record, sensors, total_routes, endpoint):
+    def save_global_record(route_record, total_routes, endpoint):
         data = fetch_dict(endpoint)
         if not data:
             data = create_default_json_msg()

--- a/scripts/run_evaluation.sh
+++ b/scripts/run_evaluation.sh
@@ -10,5 +10,5 @@ python3 ${LEADERBOARD_ROOT}/leaderboard/leaderboard_evaluator.py \
 --agent-config=${TEAM_CONFIG} \
 --debug=${DEBUG_CHALLENGE} \
 --record=${RECORD_PATH} \
+--allow-all-sensors=${ALLOW_ALL_SENSORS} \
 --resume=${RESUME}
-


### PR DESCRIPTION
This PR adds a new parameter to allow agents use any CARLA sensor. This feature can be enabled by exporting the following environment variable:
```sh
export ALLOW_ALL_SENSORS=1
```
This allows spawning any type and quantity of sensor without restrictions. By default, this parameter is set to `False`.

**IMPORTANT**. Submissions to the leadeboard will always have this parameter deactivated (i.e., submitted agents can only use allowed sensors: https://leaderboard.carla.org/get_started/#33-override-the-sensors-method).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/95)
<!-- Reviewable:end -->
