### PR TITLE
Fix docker build errors caused by pip >= 21.0

### DIFF
--- a/scripts/Dockerfile.master
+++ b/scripts/Dockerfile.master
@@ -28,8 +28,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          python3-setuptools \
          python-pip \
          python3-pip && \
-         pip install --upgrade pip && \
-         pip3 install --upgrade pip && \
+         pip install --upgrade "pip < 21.0" && \
+         pip3 install --upgrade "pip < 21.0" && \
          rm -rf /var/lib/apt/lists/*
 
 # installing conda


### PR DESCRIPTION
When building the docker image, a pip version related error may occur:

```  
Collecting pip
  Downloading https://files.pythonhosted.org/packages/52/e1/06c018197d8151383f66ebf6979d951995cf495629fc54149491f5d157d0/pip-21.2.4.tar.gz (1.6MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-LqNZZc/pip/setup.py", line 7
        def read(rel_path: str) -> str:
                         ^
    SyntaxError: invalid syntax
    
```

This is because higher version pip (>=21.0) has stopped support for python<3.5.  

This PR fixes this issue by using a proper pip version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/100)
<!-- Reviewable:end -->
