### PR TITLE
Dockerfile.master set pip version

### DIFF
--- a/scripts/Dockerfile.master
+++ b/scripts/Dockerfile.master
@@ -28,8 +28,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          python3-setuptools \
          python-pip \
          python3-pip && \
-         pip install --upgrade pip && \
-         pip3 install --upgrade pip && \
+         pip install --upgrade "pip < 21.0" && \
+         pip3 install --upgrade "pip < 21.0" && \
          rm -rf /var/lib/apt/lists/*
 
 # installing conda


### PR DESCRIPTION
pip 21.0 dropped support for Python 2.7 and Python 3.5. 
https://pip.pypa.io/en/stable/news/#v21-0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/102)
<!-- Reviewable:end -->
