### PR TITLE
New route format

### DIFF
--- a/data/new_route_mode.xml
+++ b/data/new_route_mode.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<routes>
+   <route id="0" town="Town01">
+      <weather
+         cloudiness="0"
+         wind_intensity="0"
+         precipitation="0"
+         precipitation_deposits="0"
+         wetness="0"
+         sun_azimuth_angle="0"
+         sun_altitude_angle="70"
+         fog_density="0"
+         fog_distance="0"
+      />
+      <waypoints>
+         <position x="338.0" y="226.1" z="0.0" />
+         <position x="321.2" y="194.3" z="0.0" />
+         <position x="283.1" y="194.7" z="0.0" />
+         <position x="108.8" y="195.4" z="0.0" />
+         <position x="88.6" y="210.0" z="0.0" />
+         <position x="88.4" y="309.1" z="0.0" />
+         <position x="75.3" y="326.9" z="0.0" />
+         <position x="14.3" y="326.3" z="0.0" />
+         <position x="1.9" y="299.4" z="0.0" />
+         <position x="1.6" y="170.7" z="0.0" />
+         <position x="1.4" y="47.9" z="0.0" />
+      </waypoints>
+      <scenarios>
+         <scenario name="DynamicObjectCrossing_1" type="DynamicObjectCrossing">
+            <trigger_point x="324.8" y="195.1" z="0.0" yaw="180"/>
+         </scenario>
+         <scenario name="ControlLoss_1" type="ControlLoss">
+            <trigger_point x="264.8" y="195.1" z="0.0" yaw="180"/>
+         </scenario>
+         <scenario name="HardBreak_1" type="FollowLeadingVehicleRoute">
+            <trigger_point x="212.6" y="195.1" z="0.0" yaw="180"/>
+         </scenario>
+         <scenario name="VehicleTurning_1" type="VehicleTurningRoute">
+            <trigger_point x="117.6" y="195.1" z="0.0" yaw="180"/>
+         </scenario>
+         <scenario name="DynamicObjectCrossing_2" type="DynamicObjectCrossing">
+            <trigger_point x="88.3" y="246.1" z="0.0" yaw="90"/>
+         </scenario>
+         <scenario name="VehicleTurning_2" type="VehicleTurningRoute">
+            <trigger_point x="88.3" y="302.1" z="0.0" yaw="90"/>
+         </scenario>
+         <scenario name="SignalizedJunctionRightTurn_1" type="SignalizedJunctionRightTurn">
+            <trigger_point x="88.3" y="270.1" z="0.0" yaw="90"/>
+         </scenario>
+         <scenario name="HardBreak_2" type="FollowLeadingVehicleRoute">
+            <trigger_point x="2.0" y="275.7" z="0.0" yaw="-90"/>
+         </scenario>
+         <scenario name="DynamicObjectCrossing_3" type="DynamicObjectCrossing">
+            <trigger_point x="2.0" y="209.8" z="0.0" yaw="-90"/>
+         </scenario>
+         <scenario name="ControlLoss_2" type="ControlLoss">
+            <trigger_point x="2.0" y="160.8" z="0.0" yaw="-90"/>
+         </scenario>
+         <scenario name="DynamicObjectCrossing_4" type="DynamicObjectCrossing">
+            <trigger_point x="2.0" y="120.8" z="0.0" yaw="-90"/>
+         </scenario>
+      </scenarios>
+   </route>
+</routes>
+
+
+
+

--- a/leaderboard/leaderboard_evaluator.py
+++ b/leaderboard/leaderboard_evaluator.py
@@ -382,7 +382,7 @@ class LeaderboardEvaluator(object):
         """
         Run the challenge mode
         """
-        route_indexer = RouteIndexer(args.routes, args.scenarios, args.repetitions, args.route_id)
+        route_indexer = RouteIndexer(args.routes, args.repetitions, args.route_id)
 
         if args.resume:
             route_indexer.resume(args.checkpoint)
@@ -413,39 +413,38 @@ def main():
     parser = argparse.ArgumentParser(description=description, formatter_class=RawTextHelpFormatter)
     parser.add_argument('--host', default='localhost',
                         help='IP of the host server (default: localhost)')
-    parser.add_argument('--port', default=2000, type=int, help='TCP port to listen to (default: 2000)')
+    parser.add_argument('--port', default=2000, type=int,
+                        help='TCP port to listen to (default: 2000)')
     parser.add_argument('--traffic-manager-port', default=8000, type=int,
                         help='Port to use for the TrafficManager (default: 8000)')
     parser.add_argument('--traffic-manager-seed', default=0, type=int,
                         help='Seed used by the TrafficManager (default: 0)')
-    parser.add_argument('--debug', type=int, help='Run with debug output', default=0)
+    parser.add_argument('--debug', type=int,
+                        help='Run with debug output', default=0)
     parser.add_argument('--record', type=str, default='',
                         help='Use CARLA recording feature to create a recording of the scenario')
     parser.add_argument('--timeout', default=60.0, type=float,
                         help='Set the CARLA client timeout value in seconds')
 
     # simulation setup
-    parser.add_argument('--routes',
-                        help='Name of the route to be executed. Point to the route_xml_file to be executed.',
-                        required=True)
+    parser.add_argument('--routes', required=True,
+                        help='Name of the route to be executed. Point to the route_xml_file to be executed.')
     parser.add_argument('--route-id', default='', type=str,
                         help='Execute a specific route')
-    parser.add_argument('--scenarios',
-                        help='Name of the scenario annotation file to be mixed with the route.',
-                        required=True)
-    parser.add_argument('--repetitions',
-                        type=int,
-                        default=1,
+    parser.add_argument('--repetitions', type=int, default=1,
                         help='Number of repetitions per route.')
 
     # agent-related options
-    parser.add_argument("-a", "--agent", type=str, help="Path to Agent's py file to evaluate", required=True)
-    parser.add_argument("--agent-config", type=str, help="Path to Agent's configuration file", default="")
+    parser.add_argument("-a", "--agent", type=str,
+                        help="Path to Agent's py file to evaluate", required=True)
+    parser.add_argument("--agent-config", type=str,
+                        help="Path to Agent's configuration file", default="")
 
-    parser.add_argument("--track", type=str, default='SENSORS', help="Participation track: SENSORS, MAP")
-    parser.add_argument('--resume', type=bool, default=False, help='Resume execution from last checkpoint?')
-    parser.add_argument("--checkpoint", type=str,
-                        default='./simulation_results.json',
+    parser.add_argument("--track", type=str, default='SENSORS',
+                        help="Participation track: SENSORS, MAP")
+    parser.add_argument('--resume', type=bool, default=False,
+                        help='Resume execution from last checkpoint?')
+    parser.add_argument("--checkpoint", type=str, default='./simulation_results.json',
                         help="Path to checkpoint used for saving statistics and resuming")
 
     arguments = parser.parse_args()

--- a/leaderboard/scenarios/route_scenario.py
+++ b/leaderboard/scenarios/route_scenario.py
@@ -11,6 +11,11 @@ This module provides Challenge routes as standalone scenarios
 
 from __future__ import print_function
 
+import glob
+import os
+import sys
+import importlib
+import inspect
 import py_trees
 import traceback
 
@@ -18,27 +23,10 @@ import carla
 from agents.navigation.local_planner import RoadOption
 
 from srunner.scenarioconfigs.scenario_configuration import ActorConfigurationData
-from srunner.scenariomanager.scenarioatomics.atomic_behaviors import ScenarioTriggerer
-from srunner.scenariomanager.scenarioatomics.atomic_trigger_conditions import WaitForBlackboardVariable
 from srunner.scenariomanager.carla_data_provider import CarlaDataProvider
 
-from srunner.scenarios.basic_scenario import BasicScenario
-from srunner.scenarios.background_activity import BackgroundActivity
-from srunner.scenarios.control_loss import ControlLoss
-from srunner.scenarios.follow_leading_vehicle import FollowLeadingVehicleRoute
-from srunner.scenarios.object_crash_vehicle import DynamicObjectCrossing
-from srunner.scenarios.object_crash_intersection import VehicleTurningRoute
-from srunner.scenarios.other_leading_vehicle import OtherLeadingVehicle
-from srunner.scenarios.maneuver_opposite_direction import ManeuverOppositeDirection
-from srunner.scenarios.junction_crossing_route import NoSignalJunctionCrossingRoute
-from srunner.scenarios.signalized_junction_left_turn import SignalizedJunctionLeftTurn
-from srunner.scenarios.signalized_junction_right_turn import SignalizedJunctionRightTurn
-from srunner.scenarios.opposite_vehicle_taking_priority import OppositeVehicleRunningRedLight
-from srunner.scenarios.actor_flow import EnterActorFlow, CrossActorFlow
-from srunner.scenarios.route_obstacles import Accident
-from srunner.scenarios.construction_crash_vehicle import ConstructionSetupCrossing
-
-
+from srunner.scenariomanager.scenarioatomics.atomic_behaviors import ScenarioTriggerer
+from srunner.scenariomanager.scenarioatomics.atomic_trigger_conditions import WaitForBlackboardVariable
 from srunner.scenariomanager.scenarioatomics.atomic_criteria import (CollisionTest,
                                                                      InRouteTest,
                                                                      RouteCompletionTest,
@@ -47,30 +35,15 @@ from srunner.scenariomanager.scenarioatomics.atomic_criteria import (CollisionTe
                                                                      RunningStopTest,
                                                                      ActorBlockedTest)
 
-from leaderboard.utils.route_parser import RouteParser, TRIGGER_THRESHOLD
-from leaderboard.utils.route_manipulation import interpolate_trajectory
+from srunner.scenarios.basic_scenario import BasicScenario
+from srunner.scenarios.background_activity import BackgroundActivity
 
-ROUTESCENARIO = ["RouteScenario"]
+from leaderboard.utils.route_parser import RouteParser, DIST_THRESHOLD
+from leaderboard.utils.route_manipulation import interpolate_trajectory
 
 SECONDS_GIVEN_PER_METERS = 0.8
 INITIAL_SECONDS_DELAY = 5.0
 
-NUMBER_CLASS_TRANSLATION = {
-    "Scenario1": ControlLoss,
-    "Scenario2": FollowLeadingVehicleRoute,
-    "Scenario3": DynamicObjectCrossing,
-    "Scenario4": VehicleTurningRoute,
-    "Scenario5": OtherLeadingVehicle,
-    "Scenario6": ManeuverOppositeDirection,
-    "Scenario7": OppositeVehicleRunningRedLight,
-    "Scenario8": SignalizedJunctionLeftTurn,
-    "Scenario9": SignalizedJunctionRightTurn,
-    "Scenario10": NoSignalJunctionCrossingRoute,
-    "EnterActorFlow": EnterActorFlow,
-    "Accident": Accident,
-    "ConstructionSetupCrossing": ConstructionSetupCrossing,
-    "CrossActorFlow": CrossActorFlow
-}
 
 class RouteScenario(BasicScenario):
 
@@ -87,7 +60,7 @@ class RouteScenario(BasicScenario):
         """
         self.config = config
         self.route = self._get_route(config)
-        sampled_scenario_definitions = self._get_scenarios(config)
+        sampled_scenario_definitions = self._filter_scenarios(config.scenario_configs)
 
         self.night_mode = config.weather.sun_altitude_angle < 0.0
         ego_vehicle = self._spawn_ego_vehicle()
@@ -97,7 +70,7 @@ class RouteScenario(BasicScenario):
             self._draw_waypoints(world, self.route, vertical_shift=0.1, size=0.1, persistency=self.timeout)
 
         self._build_scenarios(
-            world, ego_vehicle, sampled_scenario_definitions, 5, self.timeout, debug_mode > 0
+            world, ego_vehicle, sampled_scenario_definitions, timeout=self.timeout, debug=debug_mode > 0
         )
 
         super(RouteScenario, self).__init__(
@@ -116,22 +89,38 @@ class RouteScenario(BasicScenario):
         """
 
         # prepare route's trajectory (interpolate and add the GPS route)
-        gps_route, route = interpolate_trajectory(config.trajectory)
+        gps_route, route = interpolate_trajectory(config.keypoints)
         config.agent.set_global_plan(gps_route, route)
         return route
 
-    def _get_scenarios(self, config):
+    def _filter_scenarios(self, scenario_configs):
         """
-        Gets the scenarios that will be part of the route. Automatically filters the scenarios
-        that affect the route and, if there are two or more scenarios with very similar triggering positions,
-        one of those is randomly chosen
+        Given a list of scenarios, filters out does that don't make sense to be triggered,
+        as they are either too far from the route or don't fit with the route shape
+
         Parameters:
-        - config: Scenario configuration (RouteConfiguration)
+        - scenario_configs: list of ScenarioConfiguration
         """
-        scenario_dict = RouteParser.parse_scenario_file_to_dict(config.scenario_file)
-        potential_scenarios = RouteParser.scan_route_for_scenarios(config.town, self.route, scenario_dict)
-        sampled_scenarios = self._scenario_sampling(potential_scenarios)
-        return sampled_scenarios
+        new_scenarios_config = []
+        for scenario_config in scenario_configs:
+            # Get the trigger point of the scenario
+            trigger_point = scenario_config.trigger_points[0]
+
+            # Check if the route passes through the scenario
+            match_position = RouteParser.is_scenario_at_route(trigger_point, self.route)
+            if match_position is None:
+                print("WARNING: Ignoring scenario '{}' as it is too far from the route".format(scenario_config.name))
+                continue
+
+            # Check the route has the correct topology
+            subtype = RouteParser.get_scenario_subtype(scenario_config.name, self.route[match_position:])
+            if subtype is None:
+                print("WARNING: Ignoring scenario '{}' as it is incompatible with the route trajectory".format(scenario_config.name))
+                continue
+
+            new_scenarios_config.append(scenario_config)
+
+        return new_scenarios_config
 
     def _spawn_ego_vehicle(self):
         """Spawn the ego vehicle at the first waypoint of the route"""
@@ -194,7 +183,7 @@ class RouteScenario(BasicScenario):
         world.debug.draw_point(waypoints[0][0].location + carla.Location(z=vertical_shift), size=2*size,
                                color=carla.Color(0, 0, 128), life_time=persistency)
         world.debug.draw_point(waypoints[-1][0].location + carla.Location(z=vertical_shift), size=2*size,
-                               color=carla.Color(128, 0, 0), life_time=persistency)
+                               color=carla.Color(128, 128, 128), life_time=persistency)
 
     def _scenario_sampling(self, potential_scenarios):
         """
@@ -221,42 +210,63 @@ class RouteScenario(BasicScenario):
 
         return sampled_scenarios
 
-    def _build_scenarios(self, world, ego_vehicle, scenario_definitions,
-                         scenarios_per_tick=5, timeout=300, debug_mode=False):
+    def get_all_scenario_classes(self):
+
+        # Path of all scenario at "srunner/scenarios" folder
+        scenarios_list = glob.glob("{}/srunner/scenarios/*.py".format(os.getenv('SCENARIO_RUNNER_ROOT', "./")))
+
+        all_scenario_classes = {}
+
+        for scenario_file in scenarios_list:
+
+            # Get their module
+            module_name = os.path.basename(scenario_file).split('.')[0]
+            sys.path.insert(0, os.path.dirname(scenario_file))
+            scenario_module = importlib.import_module(module_name)
+
+            # And their members of type class
+            for member in inspect.getmembers(scenario_module, inspect.isclass):
+                # TODO: Filter out any class that isn't a child of BasicScenario
+                all_scenario_classes[member[0]] = member[1]
+
+        return all_scenario_classes
+
+    def _build_scenarios(self, world, ego_vehicle, scenario_definitions, scenarios_per_tick=5, timeout=300, debug=False):
         """
         Initializes the class of all the scenarios that will be present in the route.
         If a class fails to be initialized, a warning is printed but the route execution isn't stopped
         """
+        all_scenario_classes = self.get_all_scenario_classes()
         self.list_scenarios = []
+        ego_data = ActorConfigurationData(ego_vehicle.type_id, ego_vehicle.get_transform(), 'hero')
 
-        if debug_mode:
+        if debug:
             tmap = CarlaDataProvider.get_map()
             for scenario_config in scenario_definitions:
                 scenario_loc = scenario_config.trigger_points[0].location
                 debug_loc = tmap.get_waypoint(scenario_loc).transform.location + carla.Location(z=0.2)
                 world.debug.draw_point(debug_loc, size=0.2, color=carla.Color(128, 0, 0), life_time=timeout)
-                world.debug.draw_string(debug_loc, str(scenario_config.type), draw_shadow=False,
+                world.debug.draw_string(debug_loc, str(scenario_config.name), draw_shadow=False,
                                         color=carla.Color(0, 0, 128), life_time=timeout, persistent_lines=True)
 
         for scenario_number, scenario_config in enumerate(scenario_definitions):
-            scenario_config.ego_vehicles = [ActorConfigurationData(ego_vehicle.type_id,
-                                                                   ego_vehicle.get_transform(),
-                                                                   'hero')]
+            scenario_config.ego_vehicles = [ego_data]
             scenario_config.route_var_name = "ScenarioRouteNumber{}".format(scenario_number)
+            scenario_config.route = self.route
+
+            # Do a tick every once in a while to avoid spawning everything at the same time
+            if scenario_number % scenarios_per_tick == 0:
+                world.tick()
 
             try:
-                scenario_class = NUMBER_CLASS_TRANSLATION[scenario_config.type]
+                scenario_class = all_scenario_classes[scenario_config.type]
                 scenario_instance = scenario_class(world, [ego_vehicle], scenario_config, timeout=timeout)
-
-                # Do a tick every once in a while to avoid spawning everything at the same time
                 if scenario_number % scenarios_per_tick == 0:
-                    if CarlaDataProvider.is_sync_mode():
-                        world.tick()
-                    else:
-                        world.wait_for_tick()
+
+                    world.tick()
 
             except Exception as e:
-                if not debug_mode:
+                if not debug:
                     print("Skipping scenario '{}' due to setup error: {}".format(scenario_config.type, e))
                 else:
                     traceback.print_exc()
@@ -282,7 +292,7 @@ class RouteScenario(BasicScenario):
         It also adds the BackgroundActivity scenario, which will be active throughout the whole route.
         This behavior never ends and the end condition is given by the RouteCompletionTest criterion.
         """
-        scenario_trigger_distance = TRIGGER_THRESHOLD  # Max trigger distance between route and scenario
+        scenario_trigger_distance = DIST_THRESHOLD  # Max trigger distance between route and scenario
 
         behavior = py_trees.composites.Parallel(name="Route Behavior",
                                                 policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL)
@@ -338,15 +348,13 @@ class RouteScenario(BasicScenario):
         )
 
         for scenario in self.list_scenarios:
-
             scenario_criteria = scenario.get_criteria()
             if len(scenario_criteria) == 0:
                 continue  # No need to create anything
 
-            criteria_tree = self._create_criterion_tree(scenario,
-                scenario_criteria,
+            criteria.add_child(
+                self._create_criterion_tree(scenario, scenario_criteria)
             )
-            criteria.add_child(criteria_tree)
 
         return criteria
 
@@ -357,7 +365,7 @@ class RouteScenario(BasicScenario):
         The criteria will wait until that variable is active (the scenario has started),
         and will automatically stop when it deactivates (as the scenario has finished)
         """
-        scenario_name = scenario.name,
+        scenario_name = scenario.name
         var_name = scenario.config.route_var_name
         check_name = "WaitForBlackboardVariable: {}".format(var_name)
 

--- a/leaderboard/scenarios/route_scenario.py
+++ b/leaderboard/scenarios/route_scenario.py
@@ -103,19 +103,9 @@ class RouteScenario(BasicScenario):
         """
         new_scenarios_config = []
         for scenario_config in scenario_configs:
-            # Get the trigger point of the scenario
             trigger_point = scenario_config.trigger_points[0]
-
-            # Check if the route passes through the scenario
-            match_position = RouteParser.is_scenario_at_route(trigger_point, self.route)
-            if match_position is None:
+            if not RouteParser.is_scenario_at_route(trigger_point, self.route):
                 print("WARNING: Ignoring scenario '{}' as it is too far from the route".format(scenario_config.name))
-                continue
-
-            # Check the route has the correct topology
-            subtype = RouteParser.get_scenario_subtype(scenario_config.name, self.route[match_position:])
-            if subtype is None:
-                print("WARNING: Ignoring scenario '{}' as it is incompatible with the route trajectory".format(scenario_config.name))
                 continue
 
             new_scenarios_config.append(scenario_config)
@@ -254,15 +244,12 @@ class RouteScenario(BasicScenario):
             scenario_config.route_var_name = "ScenarioRouteNumber{}".format(scenario_number)
             scenario_config.route = self.route
 
-            # Do a tick every once in a while to avoid spawning everything at the same time
-            if scenario_number % scenarios_per_tick == 0:
-                world.tick()
-
             try:
                 scenario_class = all_scenario_classes[scenario_config.type]
                 scenario_instance = scenario_class(world, [ego_vehicle], scenario_config, timeout=timeout)
-                if scenario_number % scenarios_per_tick == 0:
 
+                # Do a tick every once in a while to avoid spawning everything at the same time
+                if scenario_number % scenarios_per_tick == 0:
                     world.tick()
 
             except Exception as e:

--- a/leaderboard/utils/route_indexer.py
+++ b/leaderboard/utils/route_indexer.py
@@ -11,9 +11,8 @@ from leaderboard.utils.checkpoint_tools import fetch_dict, create_default_json_m
 
 
 class RouteIndexer():
-    def __init__(self, routes_file, scenarios_file, repetitions, route_id):
+    def __init__(self, routes_file, repetitions, route_id):
         self._routes_file = routes_file
-        self._scenarios_file = scenarios_file
         self._repetitions = repetitions
         self._route_id = route_id
         self._configs_dict = OrderedDict()
@@ -22,7 +21,7 @@ class RouteIndexer():
         self._index = 0
 
         # retrieve routes
-        route_configurations = RouteParser.parse_routes_file(self._routes_file, self._scenarios_file, self._route_id)
+        route_configurations = RouteParser.parse_routes_file(self._routes_file, self._route_id)
 
         self.n_routes = len(route_configurations)
         self.total = self.n_routes*self._repetitions

--- a/leaderboard/utils/route_parser.py
+++ b/leaderboard/utils/route_parser.py
@@ -21,22 +21,6 @@ DIST_THRESHOLD = 2.0
 ANGLE_THRESHOLD = 10
 
 
-def convert_dict_to_transform(dicti):
-    """Convert a dict to a CARLA transform"""
-    return carla.Transform(
-        carla.Location(
-            float(dicti['x']),
-            float(dicti['y']),
-            float(dicti['z'])
-        ),
-        carla.Rotation(
-            roll=0.0,
-            pitch=0.0,
-            yaw=float(dicti['yaw'])
-        )
-    )
-
-
 def convert_elem_to_transform(elem):
     """Convert an ElementTree.Element to a CARLA transform"""
     return carla.Transform(
@@ -178,55 +162,3 @@ class RouteParser(object):
                 return position
 
         return None
-
-    @staticmethod
-    def get_scenario_subtype(scenario, route):
-        """
-        Some scenarios have subtypes depending on the route trajectory,
-        even being invalid if there isn't a valid one. As an example,
-        some scenarios need the route to turn in a specific direction,
-        and if this isn't the case, the scenario should not be considered valid.
-        This is currently only used for validity purposes.
-        :param scenario: the scenario name
-        :param route: route starting at the triggering point of the scenario
-        :return: tag representing this subtype
-        """
-
-        def is_junction_option(option):
-            """Whether or not an option is part of a junction"""
-            if option in (RoadOption.LANEFOLLOW, RoadOption.CHANGELANELEFT, RoadOption.CHANGELANERIGHT):
-                return False
-            return True
-
-        subtype = None
-
-        if scenario == 'Scenario4':  # Only if the route turns
-            for _, option in route:
-                if is_junction_option(option):
-                    if option == RoadOption.LEFT:
-                        subtype = 'S4left'
-                    elif option == RoadOption.RIGHT:
-                        subtype = 'S4right'
-                    break  # Avoid checking all of them
-        elif scenario == 'Scenario7':
-            for _, option in route:
-                if is_junction_option(option):
-                    if RoadOption.STRAIGHT == option:
-                        subtype = 'S7opposite'
-                    break
-        elif scenario == 'Scenario8':  # Only if the route turns left
-            for _, option in route:
-                if is_junction_option(option):
-                    if option == RoadOption.LEFT:
-                        subtype = 'S8left'
-                    break
-        elif scenario == 'Scenario9':  # Only if the route turns right
-            for _, option in route:
-                if is_junction_option(option):
-                    if option == RoadOption.RIGHT:
-                        subtype = 'S9right'
-                    break
-        else:
-            subtype = 'valid'
-
-        return subtype

--- a/leaderboard/utils/route_parser.py
+++ b/leaderboard/utils/route_parser.py
@@ -16,15 +16,40 @@ from agents.navigation.local_planner import RoadOption
 from srunner.scenarioconfigs.route_scenario_configuration import RouteScenarioConfiguration
 from srunner.scenarioconfigs.scenario_configuration import ScenarioConfiguration, ActorConfigurationData
 
-# TODO  check this threshold, it could be a bit larger but not so large that we cluster scenarios.
-TRIGGER_THRESHOLD = 2.0  # Threshold to say if a trigger position is new or repeated, works for matching positions
-TRIGGER_ANGLE_THRESHOLD = 10  # Threshold to say if two angles can be considering matching when matching transforms.
+# Threshold to say if a scenarios trigger position is part of the route
+DIST_THRESHOLD = 2.0
+ANGLE_THRESHOLD = 10
 
-def convert_dict_to_transform(scenario_dict):
-    """Convert a JSON dict to a CARLA transform"""
+
+def convert_dict_to_transform(dicti):
+    """Convert a dict to a CARLA transform"""
     return carla.Transform(
-        carla.Location(float(scenario_dict['x']), float(scenario_dict['y']), float(scenario_dict['z'])),
-        carla.Rotation(roll=0.0, pitch=0.0, yaw=float(scenario_dict['yaw']))
+        carla.Location(
+            float(dicti['x']),
+            float(dicti['y']),
+            float(dicti['z'])
+        ),
+        carla.Rotation(
+            roll=0.0,
+            pitch=0.0,
+            yaw=float(dicti['yaw'])
+        )
+    )
+
+
+def convert_elem_to_transform(elem):
+    """Convert an ElementTree.Element to a CARLA transform"""
+    return carla.Transform(
+        carla.Location(
+            float(elem.attrib.get('x')),
+            float(elem.attrib.get('y')),
+            float(elem.attrib.get('z'))
+        ),
+        carla.Rotation(
+            roll=0.0,
+            pitch=0.0,
+            yaw=float(elem.attrib.get('yaw'))
+        )
     )
 
 
@@ -35,24 +60,7 @@ class RouteParser(object):
     """
 
     @staticmethod
-    def parse_scenario_file_to_dict(scenario_file):
-        """
-        Parses and returns the scenario file into a dictionary
-        :param scenario_file: the filename for the anotations file
-        :return:
-        """
-        with open(scenario_file, 'r') as f:
-            scenario_dict = json.loads(f.read(), object_pairs_hook=OrderedDict)
-
-        final_dict = OrderedDict()
-
-        for town_dict in scenario_dict['available_scenarios']:
-            final_dict.update(town_dict)
-
-        return final_dict  # the file has a current maps name that is an one element vec
-
-    @staticmethod
-    def parse_routes_file(route_filename, scenario_file, single_route_id=''):
+    def parse_routes_file(route_filename, single_route_id=''):
         """
         Returns a list of route configuration elements.
         :param route_filename: the path to a set of routes.
@@ -60,7 +68,7 @@ class RouteParser(object):
         :return: List of dicts containing the waypoints, id and town of the routes
         """
 
-        list_route_descriptions = []
+        route_configs = []
         tree = ET.parse(route_filename)
         for route in tree.iter("route"):
 
@@ -68,23 +76,40 @@ class RouteParser(object):
             if single_route_id and route_id != single_route_id:
                 continue
 
-            new_config = RouteScenarioConfiguration()
-            new_config.town = route.attrib['town']
-            new_config.name = "RouteScenario_{}".format(route_id)
-            new_config.weather = RouteParser.parse_weather(route)
-            new_config.scenario_file = scenario_file
+            route_config = RouteScenarioConfiguration()
+            route_config.town = route.attrib['town']
+            route_config.name = "RouteScenario_{}".format(route_id)
+            route_config.weather = RouteParser.parse_weather(route)
 
-            waypoint_list = []  # the list of waypoints that can be found on this route
-            for waypoint in route.iter('waypoint'):
-                waypoint_list.append(carla.Location(x=float(waypoint.attrib['x']),
-                                                    y=float(waypoint.attrib['y']),
-                                                    z=float(waypoint.attrib['z'])))
+            # The list of carla.Location that serve as keypoints on this route
+            positions = []
+            for position in route.find('waypoints').iter('position'):
+                positions.append(carla.Location(x=float(position.attrib['x']),
+                                                y=float(position.attrib['y']),
+                                                z=float(position.attrib['z'])))
+            route_config.keypoints = positions
 
-            new_config.trajectory = waypoint_list
+            # The list of ScenarioConfigurations that store the scenario's data
+            scenario_configs = []
+            for scenario in route.find('scenarios').iter('scenario'):
+                scenario_config = ScenarioConfiguration()
+                scenario_config.name = scenario.attrib.get('name')
+                scenario_config.type = scenario.attrib.get('type')
 
-            list_route_descriptions.append(new_config)
+                for elem in scenario.getchildren():
+                    if elem.tag == 'trigger_point':
+                        scenario_config.trigger_points.append(convert_elem_to_transform(elem))
+                    elif elem.tag == 'other_actor':
+                        scenario_config.other_actors.append(ActorConfigurationData.parse_from_node(elem, 'scenario'))
+                    else:
+                        scenario_config.other_parameters[elem.tag] = elem.attrib
 
-        return list_route_descriptions
+                scenario_configs.append(scenario_config)
+            route_config.scenario_configs = scenario_configs
+
+            route_configs.append(route_config)
+
+        return route_configs
 
     @staticmethod
     def parse_weather(route):
@@ -95,7 +120,6 @@ class RouteParser(object):
 
         route_weather = route.find("weather")
         if route_weather is None:
-
             weather = carla.WeatherParameters(sun_altitude_angle=70, cloudiness=30)
 
         else:
@@ -131,29 +155,8 @@ class RouteParser(object):
 
         return weather
 
-
     @staticmethod
-    def get_trigger_position(scenario_trigger, existing_triggers):
-        """
-        Check if this trigger position already exists or if it is a new one.
-        :param scenario_trigger: position to be checked
-        :param existing_triggers: list with all the already found position
-        :return:
-        """
-        for trigger in existing_triggers:
-            dx = trigger.location.x - scenario_trigger.location.x
-            dy = trigger.location.y - scenario_trigger.location.y
-            distance = math.sqrt(dx * dx + dy * dy)
-
-            dyaw = (trigger.rotation.yaw - scenario_trigger.rotation.yaw) % 360
-            if distance < TRIGGER_THRESHOLD \
-                    and (dyaw < TRIGGER_ANGLE_THRESHOLD or dyaw > (360 - TRIGGER_ANGLE_THRESHOLD)):
-                return trigger
-
-        return None
-
-    @staticmethod
-    def match_trigger_to_route(trigger_transform, route):
+    def is_scenario_at_route(trigger_transform, route):
         """
         Check if the scenario is affecting the route.
         This is true if the trigger position is very close to any route point
@@ -167,8 +170,8 @@ class RouteParser(object):
 
             dyaw = (float(trigger_transform.rotation.yaw) - route_transform.rotation.yaw) % 360
 
-            return dz < TRIGGER_THRESHOLD and dpos < TRIGGER_THRESHOLD \
-                and (dyaw < TRIGGER_ANGLE_THRESHOLD or dyaw > (360 - TRIGGER_ANGLE_THRESHOLD))
+            return dz < DIST_THRESHOLD and dpos < DIST_THRESHOLD \
+                and (dyaw < ANGLE_THRESHOLD or dyaw > (360 - ANGLE_THRESHOLD))
 
         for position, [route_transform, _] in enumerate(route):
             if is_trigger_close(trigger_transform, route_transform):
@@ -227,55 +230,3 @@ class RouteParser(object):
             subtype = 'valid'
 
         return subtype
-
-    @staticmethod
-    def scan_route_for_scenarios(route_name, trajectory, world_annotations):
-        """
-        Filters all the scenarios that are affecting the route.
-        Returns a dictionary where each item is a list of all the scenarios that are close to each other
-        """
-        possible_scenarios = OrderedDict()
-
-        for town_name in world_annotations.keys():
-            if town_name != route_name:
-                continue
-
-            town_scenarios = world_annotations[town_name]
-            for scenario_data in town_scenarios:
-
-                if "scenario_type" not in scenario_data:
-                    break
-                scenario_name = scenario_data["scenario_type"]
-
-                for scenario in scenario_data["available_event_configurations"]:
-                    # Get the trigger point of the scenario
-                    trigger_point = convert_dict_to_transform(scenario.pop('transform'))
-
-                    # Check if the route passes through the scenario
-                    match_position = RouteParser.match_trigger_to_route(trigger_point, trajectory)
-                    if match_position is None:
-                        continue
-
-                    # Check the route has the correct topology
-                    subtype = RouteParser.get_scenario_subtype(scenario_name, trajectory[match_position:])
-                    if subtype is None:
-                        continue
-
-                    # Parse the scenario data
-                    scenario_config = ScenarioConfiguration()
-                    scenario_config.type = scenario_name
-                    scenario_config.subtype = subtype
-                    scenario_config.trigger_points = [trigger_point]
-                    scenario_config.route = trajectory
-                    for other in scenario.pop('other_actors', []):
-                        scenario_config.other_actors.append(ActorConfigurationData.parse_from_dict(other, 'scenario'))
-                    scenario_config.other_parameters.update(scenario)
-
-                    # Check if its location overlaps with other scenarios
-                    existing_trigger = RouteParser.get_trigger_position(trigger_point, possible_scenarios.keys())
-                    if existing_trigger:
-                        possible_scenarios[existing_trigger].append(scenario_config)
-                    else:
-                        possible_scenarios.update({trigger_point: [scenario_config]})
-
-        return possible_scenarios

--- a/scripts/manage_scenarios.py
+++ b/scripts/manage_scenarios.py
@@ -7,6 +7,7 @@ import sys
 import carla
 
 from leaderboard.utils.checkpoint_tools import fetch_dict
+from leaderboard.utils.route_parser import DIST_THRESHOLD
 
 SCENARIO_COLOR = {
     "Scenario1": [carla.Color(255, 0, 0), "Red"],
@@ -42,8 +43,8 @@ def get_color_validity(waypoint_transform, scenario_transform, scenario_type, sc
     Uses the same condition as in route_scenario to see if they will
     be differentiated
     """
-    TRIGGER_THRESHOLD = 1.4  # Routes use 1.5 (+ an error margin)
-    TRIGGER_ANGLE_THRESHOLD = 10
+    DIST_THRESHOLD = 1.4  # Routes use 1.5 (+ an error margin)
+    ANGLE_THRESHOLD = 10
 
     dx = float(waypoint_transform.location.x) - scenario_transform.location.x
     dy = float(waypoint_transform.location.y) - scenario_transform.location.y
@@ -51,12 +52,12 @@ def get_color_validity(waypoint_transform, scenario_transform, scenario_type, sc
     dpos = math.sqrt(dx * dx + dy * dy + dz * dz)
     dyaw = (float(waypoint_transform.rotation.yaw) - scenario_transform.rotation.yaw) % 360
 
-    if dpos > TRIGGER_THRESHOLD:
+    if dpos > DIST_THRESHOLD:
         if not debug:
             print("WARNING: Found a scenario with the wrong position "
                   "(Type: {}, Index: {})".format(scenario_type, scenario_index))
         return carla.Color(255, 0, 0)
-    if dyaw > TRIGGER_ANGLE_THRESHOLD and dyaw < (360 - TRIGGER_ANGLE_THRESHOLD):
+    if dyaw > ANGLE_THRESHOLD and dyaw < (360 - ANGLE_THRESHOLD):
         if not debug:
             print("WARNING: Found a scenario with the wrong orientation "
                   "(Type: {}, Index: {})".format(scenario_type, scenario_index))

--- a/scripts/run_evaluation.sh
+++ b/scripts/run_evaluation.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 python3 ${LEADERBOARD_ROOT}/leaderboard/leaderboard_evaluator.py \
---scenarios=${SCENARIOS}  \
 --routes=${ROUTES} \
 --route-id=${ROUTE_ID} \
 --repetitions=${REPETITIONS} \


### PR DESCRIPTION
The route parsing has been changed, improving readibility and functionalities.

Routes no longer need to be accompanied by a scenario file. Instead, they are now included as part of the route xml, at the `scenarios` section. While this adds a bit more of work creating the routes, this improves customization by a lot, as two routes that pass through the same point might trigger two complete different scenarios.

As such, the scenario configurations are now *.xml*, and work very similarly to the standalone configuration ones at ScenarioRunner. Its variations come from removing conflicting values such as *weather*, *town*, and *ego_vehicle* is now replaced by *trigger_point*.

An example of a new route would be somethign like this
![image](https://user-images.githubusercontent.com/58212725/158133734-40074e8e-5253-4ac7-a30a-8dc88170745f.png)

Additonally, routes now treat imports the same way as the standalone scenarios. It no longer needs to manually import all of its subscenarios, but it instead, it will now automatically import all scenarios at the `srunner/examples` folder.
As a result of the previous point, scenarios will now have to be specified by its type, not by a string such as 'Scenario1', which has to be then remapped to its correct class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/110)
<!-- Reviewable:end -->
