### PR TITLE
Added live statistics

### DIFF
--- a/leaderboard/leaderboard_evaluator.py
+++ b/leaderboard/leaderboard_evaluator.py
@@ -362,8 +362,7 @@ class LeaderboardEvaluator(object):
         # Save global statistics
         print("\033[1m> Registering the global statistics\033[0m")
         self.statistics_manager.compute_global_statistics()
-        self.statistics_manager.validate_statistics()
-        self.statistics_manager.write()
+        self.statistics_manager.validate_and_write_statistics()
 
 
 def main():

--- a/leaderboard/leaderboard_evaluator.py
+++ b/leaderboard/leaderboard_evaluator.py
@@ -89,7 +89,7 @@ class LeaderboardEvaluator(object):
         self.module_agent = importlib.import_module(module_name)
 
         # Create the ScenarioManager
-        self.manager = ScenarioManager(args.timeout, args.debug > 1)
+        self.manager = ScenarioManager(args.timeout, self.statistics_manager, args.debug)
 
         # Time control for summary purposes
         self._start_time = GameTime.get_time()
@@ -271,7 +271,7 @@ class LeaderboardEvaluator(object):
             # Load scenario and run it
             if args.record:
                 self.client.start_recorder("{}/{}_rep{}.log".format(args.record, config.name, config.repetition_index))
-            self.manager.load_scenario(scenario, self.agent_instance, config.repetition_index)
+            self.manager.load_scenario(config, scenario, self.agent_instance, config.repetition_index)
 
         except Exception as e:
             # The scenario is wrong -> set the ejecution to crashed and stop
@@ -363,6 +363,7 @@ class LeaderboardEvaluator(object):
         print("\033[1m> Registering the global statistics\033[0m")
         self.statistics_manager.compute_global_statistics()
         self.statistics_manager.validate_statistics()
+        self.statistics_manager.write()
 
 
 def main():

--- a/leaderboard/leaderboard_evaluator.py
+++ b/leaderboard/leaderboard_evaluator.py
@@ -266,7 +266,7 @@ class LeaderboardEvaluator(object):
             self._load_and_wait_for_world(args, config.town, config.ego_vehicles)
             scenario = RouteScenario(world=self.world, config=config, debug_mode=args.debug)
             config.route = scenario.route
-            self.statistics_manager.set_scenario(scenario)
+            self.statistics_manager.set_scenario(config, scenario)
 
             # Load scenario and run it
             if args.record:
@@ -406,10 +406,12 @@ def main():
                         help='Resume execution from last checkpoint?')
     parser.add_argument("--checkpoint", type=str, default='./simulation_results.json',
                         help="Path to checkpoint used for saving statistics and resuming")
+    parser.add_argument("--debug-checkpoint", type=str, default='./live_results.txt',
+                        help="Path to checkpoint used for saving live results")
 
     arguments = parser.parse_args()
 
-    statistics_manager = StatisticsManager(arguments.checkpoint)
+    statistics_manager = StatisticsManager(arguments.checkpoint, arguments.debug_checkpoint)
 
     try:
         leaderboard_evaluator = LeaderboardEvaluator(arguments, statistics_manager)

--- a/leaderboard/scenarios/route_scenario.py
+++ b/leaderboard/scenarios/route_scenario.py
@@ -77,7 +77,7 @@ class RouteScenario(BasicScenario):
         )
 
         super(RouteScenario, self).__init__(
-            config.name, [ego_vehicle], config, world, debug_mode > 1, False, criteria_enable
+            config.name, [ego_vehicle], config, world, debug_mode > 3, False, criteria_enable
         )
 
     def _get_route(self, config):

--- a/leaderboard/scenarios/scenario_manager.py
+++ b/leaderboard/scenarios/scenario_manager.py
@@ -183,7 +183,7 @@ class ScenarioManager(object):
 
             self.compute_duration_time()
 
-            if self._debug_mode > 0:
+            if self._debug_mode > 1:
                 # Update live statistics
                 self._statistics_manager.compute_route_statistics(
                     self.config,
@@ -193,7 +193,7 @@ class ScenarioManager(object):
                 )
                 self._statistics_manager.write_live_results(self.config.index)
 
-            if self._debug_mode > 1:
+            if self._debug_mode > 2:
                 print("\n")
                 py_trees.display.print_ascii_tree(
                     self.scenario_tree, show_status=True)

--- a/leaderboard/scenarios/scenario_manager.py
+++ b/leaderboard/scenarios/scenario_manager.py
@@ -45,10 +45,11 @@ class ScenarioManager(object):
     """
 
 
-    def __init__(self, timeout, debug_mode=False):
+    def __init__(self, timeout, statistics_manager, debug_mode=0):
         """
         Setups up the parameters, which will be filled at load_scenario()
         """
+        self.config = None
         self.scenario = None
         self.scenario_tree = None
         self.ego_vehicles = None
@@ -68,6 +69,8 @@ class ScenarioManager(object):
 
         self._watchdog = None
         self._agent_watchdog = None
+
+        self._statistics_manager = statistics_manager
 
         # Use the callback_id inside the signal handler to allow external interrupts
         signal.signal(signal.SIGINT, self.signal_handler)
@@ -97,13 +100,14 @@ class ScenarioManager(object):
         self._watchdog = None
         self._agent_watchdog = None
 
-    def load_scenario(self, scenario, agent, rep_number):
+    def load_scenario(self, config, scenario, agent, rep_number):
         """
         Load a new scenario
         """
 
         GameTime.restart()
         self._agent = AgentWrapper(agent)
+        self.config = config
         self.scenario = scenario
         self.scenario_tree = scenario.scenario_tree
         self.ego_vehicles = scenario.ego_vehicles
@@ -177,7 +181,19 @@ class ScenarioManager(object):
             # Tick scenario
             self.scenario_tree.tick_once()
 
-            if self._debug_mode:
+            self.compute_duration_time()
+
+            if self._debug_mode > 0:
+                # Update live statistics
+                self._statistics_manager.compute_route_statistics(
+                    self.config,
+                    self.scenario_duration_system,
+                    self.scenario_duration_game,
+                    failure_message=""
+                )
+                self._statistics_manager.write_live_results(self.config.index)
+
+            if self._debug_mode > 1:
                 print("\n")
                 py_trees.display.print_ascii_tree(
                     self.scenario_tree, show_status=True)
@@ -212,11 +228,7 @@ class ScenarioManager(object):
         if self._agent_watchdog:
             self._agent_watchdog.stop()
 
-        self.end_system_time = time.time()
-        self.end_game_time = GameTime.get_time()
-
-        self.scenario_duration_system = self.end_system_time - self.start_system_time
-        self.scenario_duration_game = self.end_game_time - self.start_game_time
+        self.compute_duration_time()
 
         if self.get_running_status():
             if self.scenario is not None:
@@ -227,6 +239,16 @@ class ScenarioManager(object):
                 self._agent = None
 
             self.analyze_scenario()
+
+    def compute_duration_time(self):
+        """
+        Computes system and game duration times
+        """
+        self.end_system_time = time.time()
+        self.end_game_time = GameTime.get_time()
+
+        self.scenario_duration_system = self.end_system_time - self.start_system_time
+        self.scenario_duration_game = self.end_game_time - self.start_game_time
 
     def analyze_scenario(self):
         """

--- a/leaderboard/scenarios/scenario_manager.py
+++ b/leaderboard/scenarios/scenario_manager.py
@@ -181,9 +181,9 @@ class ScenarioManager(object):
             # Tick scenario
             self.scenario_tree.tick_once()
 
-            self.compute_duration_time()
-
             if self._debug_mode > 1:
+                self.compute_duration_time()
+
                 # Update live statistics
                 self._statistics_manager.compute_route_statistics(
                     self.config,

--- a/leaderboard/utils/statistics_manager.py
+++ b/leaderboard/utils/statistics_manager.py
@@ -205,10 +205,6 @@ class StatisticsManager(object):
             int(x.route_id.split('_rep')[-1])
         ))
 
-    def write(self):
-        """Writes results to json"""
-        save_dict(self._endpoint, self._results.to_json())
-
     def write_live_results(self, index):
         """Writes live results"""
         route_record = self._results.checkpoint.records[index]
@@ -444,7 +440,7 @@ Last infractions:\n""".format(
         self._results.entry_status = entry_status
         self._results.eligible = ELIGIBLE_VALUES[entry_status]
 
-    def validate_statistics(self):
+    def validate_and_write_statistics(self):
         """
         Makes sure that all the relevant data is there.
         Changes the 'entry status' to 'Invalid' if this isn't the case"""
@@ -488,3 +484,5 @@ Last infractions:\n""".format(
             entry_status = 'Invalid'
             self._results.entry_status = entry_status
             self._results.eligible = ELIGIBLE_VALUES[entry_status]
+
+        save_dict(self._endpoint, self._results.to_json())

--- a/scripts/run_evaluation.sh
+++ b/scripts/run_evaluation.sh
@@ -6,6 +6,7 @@ python3 ${LEADERBOARD_ROOT}/leaderboard/leaderboard_evaluator.py \
 --repetitions=${REPETITIONS} \
 --track=${CHALLENGE_TRACK_CODENAME} \
 --checkpoint=${CHECKPOINT_ENDPOINT} \
+--debug-checkpoint=${DEBUG_CHECKPOINT_ENDPOINT} \
 --agent=${TEAM_AGENT} \
 --agent-config=${TEAM_CONFIG} \
 --debug=${DEBUG_CHALLENGE} \


### PR DESCRIPTION
This PR adds the possibility to visualize the statistics of the route while the stack is running.

This is the information provided:
```
Route id: ...

Scores:
    Driving score: ...
    Route completion: ...
    Infraction penalty: ...

Meta:
    Route length: ....
    Game duration: ...
    System duration: ...

Total infractions: ...
Last infractions: (shows the last 5 infractions)
    ....
```

Live results are enable when the `debug` argument is `>=1`. Live results are provided in a file called `live_results.txt`. This file is generated in the `checkpoint` folder indicated when executing the leaderboard.

Users can visualize this file in real time using the `watch` command:
```sh
watch -n 0.5 cat live_results.txt
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/123)
<!-- Reviewable:end -->
