### PR TITLE
Fixed ROS1 reconnection issues

### DIFF
--- a/leaderboard/autoagents/autonomous_agent.py
+++ b/leaderboard/autoagents/autonomous_agent.py
@@ -115,6 +115,10 @@ class AutonomousAgent(object):
 
         return control
 
+    @staticmethod
+    def get_ros_version():
+        return -1
+
     def set_global_plan(self, global_plan_gps, global_plan_world_coord):
         """
         Set the plan (route) for the agent

--- a/leaderboard/autoagents/ros2_agent.py
+++ b/leaderboard/autoagents/ros2_agent.py
@@ -77,6 +77,10 @@ class ROS2Agent(ROSBaseAgent):
         self.spin_thread = threading.Thread(target=rclpy.spin, args=(self.ros_node,))
         self.spin_thread.start()
 
+    @staticmethod
+    def get_ros_version():
+        return ROS2Agent.ROS_VERSION
+
     def spawn_object(self, type_, id_, transform, attributes, attach_to=0):
         spawn_point = BridgeHelper.carla2ros_pose(
             transform.location.x, transform.location.y, transform.location.z,

--- a/leaderboard/autoagents/ros_base_agent.py
+++ b/leaderboard/autoagents/ros_base_agent.py
@@ -14,7 +14,6 @@ import logging.handlers
 import os
 import queue
 import threading
-import time
 
 import carla
 import pexpect
@@ -150,7 +149,7 @@ class ROSBaseAgent(AutonomousAgent):
                 "register_all_sensors": False,
                 "ego_vehicle_role_name": "\"''\""
             },
-            wait=False
+            wait=True
         )
 
         self._agent_process = ROSLauncher("agent", ros_version=ros_version, debug=debug)


### PR DESCRIPTION
This PR fixes the reconnection issues with roslibpy and the ros-bridge server. To avoid the reconnection issue, the ROS bridge server is not closed until the last route has finished (i.e., the ROS bridge server is not restarted between routes)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/127)
<!-- Reviewable:end -->
