### PR TITLE
Improved Leaderboard shutdown

### DIFF
--- a/data/new_routes_training.xml
+++ b/data/new_routes_training.xml
@@ -179,7 +179,7 @@
          </scenario>
          <scenario name="DynamicObjectCrossing_2" type="DynamicObjectCrossing">
             <trigger_point x="20.5" y="6100.9" z="358.1" yaw="180.0"/>
-            <distance value="50"/>
+            <distance value="45"/>
             <blocker_model value="static.prop.container"/>
             <crossing_angle value="15"/>
          </scenario>
@@ -596,7 +596,7 @@
       </scenarios>
    </route>
    <route id="2" town="Town12">
-      <!-- Urban route focused on high density areas with bostacle, sunny day-->
+      <!-- Urban route focused on high density areas with obstacle, sunny day-->
       <weathers>
          <weather route_percentage="0"
             cloudiness="300" precipitation="0" precipitation_deposits="0" wetness="0"

--- a/data/new_routes_training.xml
+++ b/data/new_routes_training.xml
@@ -110,11 +110,6 @@
             <trigger_point x="-497.4" y="4884.0" z="375" yaw="90"/>
             <direction value="right"/>
          </scenario>
-         <scenario name="NonSignalizedJunctionRightTurn_2" type="NonSignalizedJunctionRightTurn">
-            <trigger_point x="-280.5" y="5043" z="374" yaw="310"/>
-            <flow_speed value="8.3"/>
-            <source_dist_interval from="25" to="40"/>
-         </scenario>
          <scenario name="ControlLoss_2" type="ControlLoss">
             <trigger_point x="-284.4" y="4834.9" z="374" yaw="180"/>
          </scenario>
@@ -138,12 +133,6 @@
             <trigger_point x="983.5" y="5442.8" z="371.2" yaw="90.1"/>
             <distance value="50"/>
             <frequency from="40" to="90"/>
-         </scenario>
-         <scenario name="HazardAtSideLane_1" type="HazardAtSideLane">
-            <trigger_point x="964.9" y="5575.4" z="370.7" yaw="180.0"/>
-            <distance value="40"/>
-            <bicycle_drive_distance value="60"/>
-            <bicycle_speed value="10"/>
          </scenario>
          <scenario name="OppositeVehicleRunningRedLight_2" type="OppositeVehicleRunningRedLight">
             <trigger_point x="830.4" y="5575.5" z="370.8" yaw="180.0"/>

--- a/leaderboard/autoagents/agent_wrapper.py
+++ b/leaderboard/autoagents/agent_wrapper.py
@@ -100,8 +100,8 @@ def validate_sensor_configuration(sensors, agent_track, selected_track):
             raise SensorConfigurationInvalid(
                 "Too many {} used! "
                 "Maximum number allowed is {}, but {} were requested.".format(sensor_type,
-                                                                                max_instances_allowed,
-                                                                                sensor_count[sensor_type]))
+                                                                              max_instances_allowed,
+                                                                              sensor_count[sensor_type]))
 
 
 class AgentWrapper(object):

--- a/leaderboard/autoagents/autonomous_agent.py
+++ b/leaderboard/autoagents/autonomous_agent.py
@@ -123,6 +123,6 @@ class AutonomousAgent(object):
         """
         Set the plan (route) for the agent
         """
-        ds_ids = downsample_route(global_plan_world_coord, 50)
+        ds_ids = downsample_route(global_plan_world_coord, 200)
         self._global_plan_world_coord = [(global_plan_world_coord[x][0], global_plan_world_coord[x][1]) for x in ds_ids]
         self._global_plan = [global_plan_gps[x] for x in ds_ids]

--- a/leaderboard/scenarios/route_scenario.py
+++ b/leaderboard/scenarios/route_scenario.py
@@ -256,12 +256,10 @@ class RouteScenario(BasicScenario):
                     world.tick()
 
             except Exception as e:
-                if not debug:
-                    print(f"Skipping scenario '{scenario_config.name}' due to setup error: {e}")
-                else:
-                    print(f"\033[93mFailed to initialize scenario {scenario_config.name}:")
-                    traceback.print_exc()
-                    print("\033[0m")
+                print(f"\033[93mSkipping scenario '{scenario_config.name}' due to setup error: {e}")
+                if debug:
+                    print(f"\n{traceback.format_exc()}")
+                print("\033[0m", end="")
                 continue
 
             self.list_scenarios.append(scenario_instance)

--- a/leaderboard/scenarios/route_scenario.py
+++ b/leaderboard/scenarios/route_scenario.py
@@ -34,7 +34,7 @@ from srunner.scenariomanager.scenarioatomics.atomic_criteria import (CollisionTe
                                                                      RunningRedLightTest,
                                                                      RunningStopTest,
                                                                      ActorBlockedTest,
-                                                                     MinSpeedRouteTest)
+                                                                     MinimumSpeedRouteTest)
 
 from srunner.scenarios.basic_scenario import BasicScenario
 from srunner.scenarios.background_activity import BackgroundBehavior
@@ -323,7 +323,7 @@ class RouteScenario(BasicScenario):
         criteria.add_child(CollisionTest(self.ego_vehicles[0], name="CollisionTest"))
         criteria.add_child(RunningRedLightTest(self.ego_vehicles[0]))
         criteria.add_child(RunningStopTest(self.ego_vehicles[0]))
-        criteria.add_child(MinSpeedRouteTest(self.ego_vehicles[0], name="MinSpeedTest"))
+        criteria.add_child(MinimumSpeedRouteTest(self.ego_vehicles[0], self.route, checkpoints=4, name="MinSpeedTest"))
 
         # These stop the route early to save computational time
         criteria.add_child(InRouteTest(

--- a/leaderboard/utils/statistics_manager.py
+++ b/leaderboard/utils/statistics_manager.py
@@ -32,8 +32,8 @@ PENALTY_PERC_DICT = {
     # Traffic events that substract a varying amount of points. This is the per unit value.
     # 'increases' means that the higher the value, the higher the penalty.
     # 'decreases' means that the ideal value is 100 and the lower the value, the higher the penalty.
-    TrafficEventType.OUTSIDE_ROUTE_LANES_INFRACTION: [1, 'increases'],
-    TrafficEventType.MIN_SPEED_INFRACTION: [0.2, 'decreases'],
+    TrafficEventType.OUTSIDE_ROUTE_LANES_INFRACTION: [0, 'increases'],  # All route traversed through outside lanes is ignored
+    TrafficEventType.MIN_SPEED_INFRACTION: [0.7, 'decreases'],
 }
 
 PENALTY_NAME_DICT = {
@@ -315,9 +315,9 @@ class StatisticsManager(object):
             event_value = event.get_dict()['percentage']
             penalty_value, penalty_type = PENALTY_PERC_DICT[event.get_type()]
             if penalty_type == "decreases":
-                score_penalty *= (1 - penalty_value * (1 - event_value / 100))
+                score_penalty *= (1 - (1 - penalty_value) * (1 - event_value / 100))
             elif penalty_type == "increases":
-                score_penalty *= (1 - penalty_value * event_value / 100)
+                score_penalty *= (1 - (1 - penalty_value) * event_value / 100)
             else:
                 raise ValueError("Found a criteria with an unknown penalty type")
             return score_penalty

--- a/scripts/scenario_creator.py
+++ b/scripts/scenario_creator.py
@@ -180,7 +180,6 @@ SCENARIO_TYPES ={
     ],
     "ParkingExit": [
         ["direction", "choice"],
-        ["flow_distance", "value"],
         ["front_vehicle_distance", "value"],
         ["behind_vehicle_distance", "value"],
     ],

--- a/scripts/scenario_creator.py
+++ b/scripts/scenario_creator.py
@@ -17,23 +17,8 @@ from agents.navigation.global_route_planner import GlobalRoutePlanner
 LIFE_TIME = 10000
 
 SCENARIO_TYPES ={
-    # Old scenarios
-    "ControlLoss": [
-    ],
-    "HardBreakRoute": [
-    ],
-    "DynamicObjectCrossing": [
-        ["distance", "value"],
-        ["direction", "value"],
-        ["blocker_model", "value"],
-        ["crossing_angle", "value"]
-    ],
-    "VehicleTurningRoute": [
-    ],
-    "VehicleTurningRoutePedestrian": [
-    ],
-    "BlockedIntersection": [
-    ],
+
+    # Junction scenarios
     "SignalizedJunctionLeftTurn": [
         ["flow_speed", "value"],
         ["source_dist_interval", "interval"],
@@ -45,7 +30,6 @@ SCENARIO_TYPES ={
     "OppositeVehicleRunningRedLight": [
         ["direction", "choice"],
     ],
-    # Old junction scenarios, non signalized version
     "NonSignalizedJunctionLeftTurn": [
         ["flow_speed", "value"],
         ["source_dist_interval", "interval"],
@@ -57,7 +41,14 @@ SCENARIO_TYPES ={
     "OppositeVehicleTakingPriority": [
         ["direction", "choice"],
     ],
+
     # Crossing actors
+    "DynamicObjectCrossing": [
+        ["distance", "value"],
+        ["direction", "value"],
+        ["blocker_model", "value"],
+        ["crossing_angle", "value"]
+    ],
     "ParkingCrossingPedestrian": [
         ["distance", "value"],
         ["direction", "choice"],
@@ -65,6 +56,13 @@ SCENARIO_TYPES ={
     ],
     "PedestrianCrossing": [
     ],
+    "VehicleTurningRoute": [
+    ],
+    "VehicleTurningRoutePedestrian": [
+    ],
+    "BlockedIntersection": [
+    ],
+
     # Actor flows
     "EnterActorFlow": [
         ["start_actor_flow", "location driving"],
@@ -113,6 +111,7 @@ SCENARIO_TYPES ={
         ["flow_speed", "value"],
         ["source_dist_interval", "interval"],
     ],
+
     # Route obstacles
     "ConstructionObstacle": [
         ["distance", "value"],
@@ -141,10 +140,6 @@ SCENARIO_TYPES ={
         ["distance", "value"],
         ["frequency", "interval"],
     ],
-    "VehicleOpensDoor": [
-        ["distance", "value"],
-        ["speed", "value"],
-    ],
     "VehicleOpensDoorTwoWays": [
         ["distance", "value"],
         ["frequency", "interval"],
@@ -161,6 +156,10 @@ SCENARIO_TYPES ={
         ["bicycle_drive_distance", "value"],
         ["bicycle_speed", "value"],
     ],
+    "InvadingTurn": [
+        ["distance", "value"],
+        ["offset", "value"],
+    ],
 
     # Cut ins
     "HighwayCutIn": [
@@ -171,30 +170,25 @@ SCENARIO_TYPES ={
     ],
     "StaticCutIn": [
         ["distance", "value"],
-        ["speed", "value"],
         ["direction", "choice"],
     ],
 
-    # Highway
-    "YieldToEmergencyVehicle": [
-        ["distance", "value"],
-    ],
-
     # Others
-    "BlockedIntersection": [
+    "ControlLoss": [
     ],
-    "InvadingTurn": [
-        ["distance", "value"],
-        ["offset", "value"],
+    "HardBreakRoute": [
     ],
-
-    # Special ones
     "ParkingExit": [
         ["direction", "choice"],
         ["flow_distance", "value"],
         ["front_vehicle_distance", "value"],
         ["behind_vehicle_distance", "value"],
     ],
+    "YieldToEmergencyVehicle": [
+        ["distance", "value"],
+    ],
+
+    # Special ones
     "BackgroundActivityParametrizer": [
         ["num_front_vehicles", "value"],
         ["num_back_vehicles", "value"],

--- a/scripts/scenario_creator.py
+++ b/scripts/scenario_creator.py
@@ -9,7 +9,6 @@
 import argparse
 from lxml import etree
 import sys
-import math
 
 import carla
 
@@ -30,6 +29,10 @@ SCENARIO_TYPES ={
         ["crossing_angle", "value"]
     ],
     "VehicleTurningRoute": [
+    ],
+    "VehicleTurningRoutePedestrian": [
+    ],
+    "BlockedIntersection": [
     ],
     "SignalizedJunctionLeftTurn": [
         ["flow_speed", "value"],
@@ -61,10 +64,6 @@ SCENARIO_TYPES ={
         ["crossing_angle", "value"],
     ],
     "PedestrianCrossing": [
-        # ["start_walker_flow", "location sidewalk"],
-        # ["end_walker_flow_1", "location sidewalk probability"],
-        # ["end_walker_flow_2", "location sidewalk probability"],
-        # ["source_dist_interval", "interval"],
     ],
     # Actor flows
     "EnterActorFlow": [


### PR DESCRIPTION
This PR focused on fixing several issues when shutting down the Leaderboard due to an error (either due to the LB itself, CARLA's server, or the agent), as it is of paramount importance that regardless of what happens, the information of the simulation is properly saved.

Some of the bugs found were:
- Watchdog: they weren't properly shutting down the simulation
- Statistics manager: Shutting down mid simulation caused some data to be missing, breaking it

Others:
- Fixed bug causing the leaderboard to crash when the route timeout was triggered
- At roads, increased the distance between points part of the stack planner to 200

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/131)
<!-- Reviewable:end -->
