### PR TITLE
Fixed bug with scenario thread blocks

### DIFF
--- a/leaderboard/scenarios/scenario_manager.py
+++ b/leaderboard/scenarios/scenario_manager.py
@@ -70,6 +70,7 @@ class ScenarioManager(object):
 
         self._watchdog = None
         self._agent_watchdog = None
+        self._scenario_thread = None
 
         self._statistics_manager = statistics_manager
 
@@ -151,8 +152,8 @@ class ScenarioManager(object):
         self._running = True
 
         # Thread for build_scenarios
-        t = threading.Thread(target=self.build_scenarios_loop, args=(self._debug_mode > 0, ))
-        t.start()
+        self._scenario_thread = threading.Thread(target=self.build_scenarios_loop, args=(self._debug_mode > 0, ))
+        self._scenario_thread.start()
 
         while self._running:
             self._tick_scenario()
@@ -254,6 +255,11 @@ class ScenarioManager(object):
                 self._agent_wrapper = None
 
             self.analyze_scenario()
+
+        # Make sure the scenario thread finishes to avoid blocks
+        self._running = False
+        self._scenario_thread.join()
+        self._scenario_thread = None
 
     def compute_duration_time(self):
         """


### PR DESCRIPTION
Fixed an issue where the simulation could potentially block after a crash

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/158)
<!-- Reviewable:end -->
