### PR TITLE
Fix KeyError when using DummyAgent

### DIFF
--- a/leaderboard/autoagents/dummy_agent.py
+++ b/leaderboard/autoagents/dummy_agent.py
@@ -56,7 +56,7 @@ class DummyAgent(AutonomousAgent):
             {'type': 'sensor.lidar.ray_cast', 'x': 0.7, 'y': -0.4, 'z': 1.60, 'roll': 0.0, 'pitch': 0.0,
              'yaw': -45.0, 'id': 'LIDAR'},
             {'type': 'sensor.other.radar', 'x': 0.7, 'y': -0.4, 'z': 1.60, 'roll': 0.0, 'pitch': 0.0,
-             'yaw': -45.0, 'fov': 30, 'id': 'RADAR'},
+             'yaw': -45.0, 'fov': 30, 'id': 'RADAR', 'horizontal_fov' : 30.0, 'vertical_fov' : 30.0},
             {'type': 'sensor.other.gnss', 'x': 0.7, 'y': -0.4, 'z': 1.60, 'id': 'GPS'},
             {'type': 'sensor.other.imu', 'x': 0.7, 'y': -0.4, 'z': 1.60, 'roll': 0.0, 'pitch': 0.0,
              'yaw': -45.0, 'id': 'IMU'},


### PR DESCRIPTION
The [DummyAgent](https://github.com/carla-simulator/leaderboard/blob/111a48f9099c08a2f1068ee8aea2ad56ce52ef9d/leaderboard/autoagents/dummy_agent.py#L58) sensors does not add two keys for the radar sensor, causing an issue later on; [here](https://github.com/carla-simulator/leaderboard/blob/da62c1b75124d6f24b47d4218e0f7169445441ae/leaderboard/autoagents/agent_wrapper.py#L173)

```py
Traceback (most recent call last):
  File ".../leaderboard/leaderboard_evaluator.py", line 342, in _load_and_run_scenario
    self.manager.load_scenario(self.route_scenario, self.agent_instance, config.index, config.repetition_index)
  File ".../leaderboard/leaderboard/scenarios/scenario_manager.py", line 125, in load_scenario
    self._agent_wrapper.setup_sensors(self.ego_vehicles[0])
  File ".../leaderboard/leaderboard/autoagents/agent_wrapper.py", line 225, in setup_sensors
    type_, id_, sensor_transform, attributes = self._preprocess_sensor_spec(sensor_spec)
  File ".../leaderboard/leaderboard/autoagents/agent_wrapper.py", line 174, in _preprocess_sensor_spec
    attributes['vertical_fov'] = str(sensor_spec['vertical_fov'])  # degrees
KeyError: 'vertical_fov'
```

---

This PR adds the `vertical_fov` and `horizontal_fov`keys to the dummy agents sensors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/168)
<!-- Reviewable:end -->
