### PR TITLE
Remove deprecation warnings for version checking in 3.8 & 3.10+ (2.7 backward compatible)

### DIFF
--- a/leaderboard/leaderboard_evaluator.py
+++ b/leaderboard/leaderboard_evaluator.py
@@ -49,7 +49,7 @@ except ModuleNotFoundError:
         return Version(pkg_resources.get_distribution("carla").version)
     
     
-MIN_CARLA_VERSION = Version("0.9.10.1")
+MIN_CARLA_VERSION = Version("0.9.15")
 
 sensors_to_icons = {
     'sensor.camera.rgb':        'carla_camera',


### PR DESCRIPTION
Removes two deprecation warnings that come up in newer python version:
- distutils will be removed in Python3.12, and marked as deprecated in 3.10 [PEP 632](https://peps.python.org/pep-0632/)
- pkg_version, should not be used in newer versions of setuptools https://setuptools.pypa.io/en/latest/pkg_resources.html

This PR can still be used with older Python version that do not provide the new modules.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/172)
<!-- Reviewable:end -->
