### PR TITLE
Removed Opendrive reading frequency

### DIFF
--- a/leaderboard/autoagents/agent_wrapper.py
+++ b/leaderboard/autoagents/agent_wrapper.py
@@ -144,7 +144,8 @@ class AgentWrapper(object):
         attributes = {}
 
         if type_ == 'sensor.opendrive_map':
-            attributes['reading_frequency'] = sensor_spec['reading_frequency']
+            delta_time = CarlaDataProvider.get_world().get_settings().fixed_delta_seconds
+            attributes['reading_frequency'] = 1 / delta_time
             sensor_location = carla.Location()
             sensor_rotation = carla.Rotation()
 


### PR DESCRIPTION
This PR removed the special reading frequency of the Opendrive sensor, instead sending it to the agent on each tick, the same as all the other sensors.

Issue #169 highlights one the issues caused by the opendrive having a special reading frequency, and this didn't really make sense in the first place, as sensing the opendrive data each tick doesn't affect performance

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/174)
<!-- Reviewable:end -->
