### PR TITLE
Fix comment about radar data

### DIFF
--- a/leaderboard/envs/sensor_interface.py
+++ b/leaderboard/envs/sensor_interface.py
@@ -164,7 +164,7 @@ class CallBack(object):
         self._data_provider.update_sensor(tag, points, lidar_data.frame)
 
     def _parse_radar_cb(self, radar_data, tag):
-        # [depth, azimuth, altitute, velocity]
+        # [depth, altitute, azimuth, velocity]
         points = np.frombuffer(radar_data.raw_data, dtype=np.dtype('f4'))
         points = copy.deepcopy(points)
         points = np.reshape(points, (int(points.shape[0] / 4), 4))


### PR DESCRIPTION
According to the [sensor reference](https://carla.readthedocs.io/en/latest/ref_sensors/#radar-sensor), data fields of a radar point is `[vel, azimuth, altitude, depth]`. Therefore the output of the callback should be `[depth, altitude, azimuth, vel]` (because of `np.flip`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/180)
<!-- Reviewable:end -->
