### PR TITLE
Python 3.9+ support for route_parser; deprecated xml code.

### DIFF
--- a/leaderboard/utils/route_parser.py
+++ b/leaderboard/utils/route_parser.py
@@ -129,7 +129,7 @@ class RouteParser(object):
                 scenario_config.name = scenario.attrib.get('name')
                 scenario_config.type = scenario.attrib.get('type')
 
-                for elem in scenario.getchildren():
+                for elem in list(scenario):
                     if elem.tag == 'trigger_point':
                         scenario_config.trigger_points.append(convert_elem_to_transform(elem))
                     elif elem.tag == 'other_actor':


### PR DESCRIPTION
This PR adds the already merged one-line fix from https://github.com/carla-simulator/scenario_runner/pull/1053 

> Replace xml.etree.ElementTree.Element.getchildren method which is deprecated from python 3.2 and removed in python 3.9 with a suggested replacement https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren

```diff
- for elem in scenario.getchildren():
+ for elem in list(scenario):
```

Tested with Python 3.7 and 3.10+; from the deprecation notice should work with 3.2+

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/182)
<!-- Reviewable:end -->
