### PR TITLE
Fix typo in statistics_manager

### DIFF
--- a/leaderboard/utils/statistics_manager.py
+++ b/leaderboard/utils/statistics_manager.py
@@ -19,7 +19,7 @@ from srunner.scenariomanager.traffic_events import TrafficEventType
 from leaderboard.utils.checkpoint_tools import fetch_dict, save_dict
 
 PENALTY_VALUE_DICT = {
-    # Traffic events that substract a set amount of points.
+    # Traffic events that subtract a set amount of points.
     TrafficEventType.COLLISION_PEDESTRIAN: 0.5,
     TrafficEventType.COLLISION_VEHICLE: 0.6,
     TrafficEventType.COLLISION_STATIC: 0.65,
@@ -29,7 +29,7 @@ PENALTY_VALUE_DICT = {
     TrafficEventType.YIELD_TO_EMERGENCY_VEHICLE: 0.7
 }
 PENALTY_PERC_DICT = {
-    # Traffic events that substract a varying amount of points. This is the per unit value.
+    # Traffic events that subtract a varying amount of points. This is the per unit value.
     # 'increases' means that the higher the value, the higher the penalty.
     # 'decreases' means that the ideal value is 100 and the lower the value, the higher the penalty.
     TrafficEventType.OUTSIDE_ROUTE_LANES_INFRACTION: [0, 'increases'],  # All route traversed through outside lanes is ignored
@@ -366,12 +366,12 @@ class StatisticsManager(object):
 
             for node in self._scenario.get_criteria():
                 for event in node.events:
-                    # Traffic events that substract a set amount of points
+                    # Traffic events that subtract a set amount of points
                     if event.get_type() in PENALTY_VALUE_DICT:
                         score_penalty *= PENALTY_VALUE_DICT[event.get_type()]
                         set_infraction_message()
 
-                    # Traffic events that substract a varying amount of points
+                    # Traffic events that subtract a varying amount of points
                     elif event.get_type() in PENALTY_PERC_DICT:
                         score_penalty = set_score_penalty(score_penalty)
                         set_infraction_message()


### PR DESCRIPTION
This pull request contains a minor spelling correction in the comments within the file `leaderboard/utils/statistics_manager.py`. Specifically, it fixes the typo "substract" to the correct spelling "subtract".

### Detailed changes:

- Corrected the spelling of "subtract" in comments describing traffic events related to scoring penalties. [[1\]](diffhunk://#diff-5447acb097298402c66c1aecb900db4fa9ad7fa1b77ea8295000d1048672ad11L22-R22) [[2\]](diffhunk://#diff-5447acb097298402c66c1aecb900db4fa9ad7fa1b77ea8295000d1048672ad11L32-R32) [[3\]](diffhunk://#diff-5447acb097298402c66c1aecb900db4fa9ad7fa1b77ea8295000d1048672ad11L369-R374)

This is a small contribution aimed at improving readability and accuracy of the documentation comments.

Thank you for maintaining this project! 😊✨

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/leaderboard/191)
<!-- Reviewable:end -->
